### PR TITLE
Fix admin view templates and route usage

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -88,5 +88,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/app/features/admin/views/category-detail.component.ts
+++ b/src/app/features/admin/views/category-detail.component.ts
@@ -10,7 +10,9 @@ import { ActivatedRoute } from '@angular/router';
   `
 })
 export class AdminCategoryDetailComponent {
-  readonly categoryId = this.route.snapshot.paramMap.get('id');
+  readonly categoryId: string | null;
 
-  constructor(private readonly route: ActivatedRoute) {}
+  constructor(private readonly route: ActivatedRoute) {
+    this.categoryId = this.route.snapshot.paramMap.get('id');
+  }
 }

--- a/src/app/features/admin/views/customer-detail.component.ts
+++ b/src/app/features/admin/views/customer-detail.component.ts
@@ -4,13 +4,15 @@ import { ActivatedRoute } from '@angular/router';
 @Component({
   selector: 'app-admin-customer-detail',
   standalone: true,
-  template: 
+  template: `
     <h1>Customer Detail</h1>
     <p>ID: {{ customerId }}</p>
-  
+  `
 })
 export class AdminCustomerDetailComponent {
-  readonly customerId = this.route.snapshot.paramMap.get('id');
+  readonly customerId: string | null;
 
-  constructor(private readonly route: ActivatedRoute) {}
+  constructor(private readonly route: ActivatedRoute) {
+    this.customerId = this.route.snapshot.paramMap.get('id');
+  }
 }

--- a/src/app/features/admin/views/inventory.component.ts
+++ b/src/app/features/admin/views/inventory.component.ts
@@ -3,8 +3,8 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-admin-inventory',
   standalone: true,
-  template: 
+  template: `
     <h1>Inventory Management</h1>
-  
+  `
 })
 export class AdminInventoryComponent {}

--- a/src/app/features/admin/views/product-detail.component.ts
+++ b/src/app/features/admin/views/product-detail.component.ts
@@ -10,7 +10,9 @@ import { ActivatedRoute } from '@angular/router';
   `
 })
 export class AdminProductDetailComponent {
-  readonly productId = this.route.snapshot.paramMap.get('id');
+  readonly productId: string | null;
 
-  constructor(private readonly route: ActivatedRoute) {}
+  constructor(private readonly route: ActivatedRoute) {
+    this.productId = this.route.snapshot.paramMap.get('id');
+  }
 }

--- a/src/app/features/admin/views/reports.component.ts
+++ b/src/app/features/admin/views/reports.component.ts
@@ -3,8 +3,8 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-admin-reports',
   standalone: true,
-  template: 
+  template: `
     <h1>Reports</h1>
-  
+  `
 })
 export class AdminReportsComponent {}

--- a/src/app/features/admin/views/reservation-detail.component.ts
+++ b/src/app/features/admin/views/reservation-detail.component.ts
@@ -10,7 +10,9 @@ import { ActivatedRoute } from '@angular/router';
   `
 })
 export class AdminReservationDetailComponent {
-  readonly reservationId = this.route.snapshot.paramMap.get('id');
+  readonly reservationId: string | null;
 
-  constructor(private readonly route: ActivatedRoute) {}
+  constructor(private readonly route: ActivatedRoute) {
+    this.reservationId = this.route.snapshot.paramMap.get('id');
+  }
 }

--- a/src/app/features/admin/views/sale-detail.component.ts
+++ b/src/app/features/admin/views/sale-detail.component.ts
@@ -4,13 +4,15 @@ import { ActivatedRoute } from '@angular/router';
 @Component({
   selector: 'app-admin-sale-detail',
   standalone: true,
-  template: 
+  template: `
     <h1>Sale Detail</h1>
     <p>ID: {{ saleId }}</p>
-  
+  `
 })
 export class AdminSaleDetailComponent {
-  readonly saleId = this.route.snapshot.paramMap.get('id');
+  readonly saleId: string | null;
 
-  constructor(private readonly route: ActivatedRoute) {}
+  constructor(private readonly route: ActivatedRoute) {
+    this.saleId = this.route.snapshot.paramMap.get('id');
+  }
 }

--- a/src/app/features/admin/views/sales-list.component.ts
+++ b/src/app/features/admin/views/sales-list.component.ts
@@ -3,8 +3,8 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-admin-sales-list',
   standalone: true,
-  template: 
+  template: `
     <h1>Sales</h1>
-  
+  `
 })
 export class AdminSalesListComponent {}

--- a/src/app/features/public/views/catalog-list.component.ts
+++ b/src/app/features/public/views/catalog-list.component.ts
@@ -88,7 +88,7 @@ export class CatalogListComponent {
     };
 
     if (this.search.trim()) {
-      params.search = this.search.trim();
+      params['search'] = this.search.trim();
     }
 
     this.api.list(params).subscribe({


### PR DESCRIPTION
## Summary
- wrap admin component inline templates in template strings so Angular recognizes them
- initialize route-dependent identifiers in constructors to avoid using dependencies before injection
- disable Angular CLI analytics prompts and ensure catalog search params use bracket notation

## Testing
- `npm test -- --watch=false` *(fails: Chrome browser binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a333d7588329a58d07daf2252326