### PR TITLE
Implement admin inventory and sales workflows

### DIFF
--- a/src/app/core/api/reservations.api.ts
+++ b/src/app/core/api/reservations.api.ts
@@ -2,13 +2,31 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { ReservationCancelRequest, ReservationCreateDTO, ReservationPickupRequest, ReservationViewDTO } from '../models/reservation';
+import { PageRequest, PageResponse } from '../models/pagination';
+import {
+  ReservationCancelRequest,
+  ReservationCreateDTO,
+  ReservationPickupRequest,
+  ReservationViewDTO
+} from '../models/reservation';
 
 @Injectable({ providedIn: 'root' })
 export class ReservationsApi {
   private readonly http = inject(HttpClient);
   private readonly baseUrl = environment.apiBaseUrl;
   private readonly resource = `${this.baseUrl}/api/v1/reservations`;
+
+  list(params?: PageRequest & { status?: string }): Observable<PageResponse<ReservationViewDTO>> {
+    let httpParams = new HttpParams();
+    if (params) {
+      Object.entries(params).forEach(([key, value]) => {
+        if (value !== undefined && value !== null) {
+          httpParams = httpParams.set(key, String(value));
+        }
+      });
+    }
+    return this.http.get<PageResponse<ReservationViewDTO>>(this.resource, { params: httpParams });
+  }
 
   create(payload: ReservationCreateDTO): Observable<ReservationViewDTO> {
     return this.http.post<ReservationViewDTO>(this.resource, payload);

--- a/src/app/core/models/inventory.ts
+++ b/src/app/core/models/inventory.ts
@@ -1,6 +1,6 @@
 /**
  * Inventory adjustment record.
- * Endpoint: GET/POST /api/v1/inventory/adjustments
+ * Endpoint: POST /api/v1/inventory/adjust
  */
 export interface InventoryAdjustmentResponse {
   id: string;
@@ -13,7 +13,7 @@ export interface InventoryAdjustmentResponse {
 
 /**
  * Create inventory adjustment request.
- * Endpoint: POST /api/v1/inventory/adjustments
+ * Endpoint: POST /api/v1/inventory/adjust
  */
 export interface InventoryAdjustmentRequest {
   productId: string;

--- a/src/app/core/models/public.ts
+++ b/src/app/core/models/public.ts
@@ -34,6 +34,7 @@ export interface PublicReservationCreateRequest {
   productId: string;
   quantity: number;
   desiredPickupDate?: string; // ISO date string
+  customerDocument?: string; // e.g. DNI
   customerName: string;
   customerEmail?: string;
   customerPhone?: string;

--- a/src/app/core/models/sale.ts
+++ b/src/app/core/models/sale.ts
@@ -39,7 +39,7 @@ export interface SaleViewDTO extends SaleDTO {}
 
 /**
  * Daily sales totals for reporting.
- * Endpoint: GET /api/v1/reports/daily-sales?date=YYYY-MM-DD
+ * Endpoint: GET /api/v1/reports/sales/daily?start=&end=
  */
 export interface DailySalesTotalsDTO {
   date: string; // YYYY-MM-DD

--- a/src/app/core/utils/index.ts
+++ b/src/app/core/utils/index.ts
@@ -1,1 +1,1 @@
-// Utility exports placeholder
+export * from './slugify';

--- a/src/app/core/utils/slugify.ts
+++ b/src/app/core/utils/slugify.ts
@@ -1,0 +1,9 @@
+export function slugify(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}

--- a/src/app/features/admin/views/categories-list.component.ts
+++ b/src/app/features/admin/views/categories-list.component.ts
@@ -1,10 +1,145 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { finalize } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CategoriesApi } from '../../../core/api/categories.api';
+import { CategoryViewDTO } from '../../../core/models/category';
+import { PageResponse } from '../../../core/models/pagination';
 
 @Component({
   selector: 'app-admin-categories-list',
   standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterModule],
   template: `
-    <h1>Admin Categories</h1>
+    <section class="page-header">
+      <h1>Categorías</h1>
+      <a routerLink="/admin/categories/new" class="btn">Crear categoría</a>
+    </section>
+
+    <form class="filters" [formGroup]="filterForm" (ngSubmit)="applyFilters()">
+      <label>
+        Búsqueda
+        <input type="text" formControlName="search" placeholder="Nombre o slug" />
+      </label>
+
+      <label>
+        Estado
+        <select formControlName="isActive">
+          <option value="">Todos</option>
+          <option value="true">Activas</option>
+          <option value="false">Inactivas</option>
+        </select>
+      </label>
+
+      <div class="filter-actions">
+        <button type="submit">Aplicar</button>
+        <button type="button" (click)="resetFilters()">Limpiar</button>
+      </div>
+    </form>
+
+    <section *ngIf="error" class="alert error">{{ error }}</section>
+    <section *ngIf="loading" class="loading">Cargando categorías…</section>
+
+    <table *ngIf="!loading && categories.length" class="data-table">
+      <thead>
+        <tr>
+          <th>Nombre</th>
+          <th>Slug</th>
+          <th>Estado</th>
+          <th>Productos</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let category of categories">
+          <td>{{ category.name }}</td>
+          <td>{{ category.slug }}</td>
+          <td>{{ category.isActive ? 'Activa' : 'Inactiva' }}</td>
+          <td>{{ category.productCount ?? '—' }}</td>
+          <td>
+            <a [routerLink]="['/admin/categories', category.id]">Editar</a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p *ngIf="!loading && !categories.length" class="empty-state">No hay categorías para mostrar.</p>
+
+    <nav class="pagination" *ngIf="!loading && totalPages > 1">
+      <button type="button" (click)="goToPage(page - 1)" [disabled]="page <= 1">Anterior</button>
+      <span>Página {{ page }} de {{ totalPages }}</span>
+      <button type="button" (click)="goToPage(page + 1)" [disabled]="page >= totalPages">Siguiente</button>
+    </nav>
   `
 })
-export class AdminCategoriesListComponent {}
+export class AdminCategoriesListComponent {
+  private readonly categoriesApi = inject(CategoriesApi);
+  private readonly fb = inject(FormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly filterForm = this.fb.nonNullable.group({
+    search: [''],
+    isActive: ['']
+  });
+
+  categories: CategoryViewDTO[] = [];
+  loading = false;
+  error: string | null = null;
+  page = 1;
+  pageSize = 10;
+  totalPages = 1;
+  totalItems = 0;
+
+  constructor() {
+    this.loadCategories(1);
+  }
+
+  applyFilters(): void {
+    this.loadCategories(1);
+  }
+
+  resetFilters(): void {
+    this.filterForm.reset({ search: '', isActive: '' });
+    this.loadCategories(1);
+  }
+
+  goToPage(page: number): void {
+    if (page < 1 || page > this.totalPages) return;
+    this.loadCategories(page);
+  }
+
+  private loadCategories(page: number): void {
+    this.loading = true;
+    this.error = null;
+    const { search, isActive } = this.filterForm.getRawValue();
+    this.categoriesApi
+      .list({
+        page,
+        pageSize: this.pageSize,
+        search: search || undefined,
+        isActive: isActive ? isActive === 'true' : undefined
+      })
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.loading = false;
+        })
+      )
+      .subscribe({
+        next: response => this.handleResponse(response),
+        error: () => {
+          this.error = 'No se pudieron cargar las categorías.';
+        }
+      });
+  }
+
+  private handleResponse(response: PageResponse<CategoryViewDTO>): void {
+    this.categories = response.items;
+    this.page = response.page;
+    this.pageSize = response.pageSize;
+    this.totalPages = response.totalPages;
+    this.totalItems = response.totalItems;
+  }
+}

--- a/src/app/features/admin/views/category-detail.component.ts
+++ b/src/app/features/admin/views/category-detail.component.ts
@@ -1,18 +1,162 @@
-import { Component } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { finalize } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CategoriesApi } from '../../../core/api/categories.api';
+import { CategoryCreateDTO, CategoryUpdateDTO, CategoryViewDTO } from '../../../core/models/category';
+import { slugify } from '../../../core/utils/slugify';
 
 @Component({
   selector: 'app-admin-category-detail',
   standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterModule],
   template: `
-    <h1>Category Detail</h1>
-    <p>ID: {{ categoryId }}</p>
+    <a routerLink="/admin/categories">&larr; Volver</a>
+
+    <h1>{{ isEdit ? 'Editar categoría' : 'Crear categoría' }}</h1>
+
+    <section *ngIf="loading" class="loading">Cargando…</section>
+    <section *ngIf="error" class="alert error">{{ error }}</section>
+    <section *ngIf="message" class="alert success">{{ message }}</section>
+
+    <form *ngIf="!loading" [formGroup]="form" (ngSubmit)="submit()" class="form-grid">
+      <label>
+        Nombre
+        <input type="text" formControlName="name" required />
+        <span class="error" *ngIf="form.controls.name.invalid && form.controls.name.touched">
+          El nombre es obligatorio.
+        </span>
+      </label>
+
+      <label>
+        Slug
+        <input type="text" formControlName="slug" required />
+        <span class="hint">Se generará automáticamente a partir del nombre si se deja vacío.</span>
+      </label>
+
+      <label class="full-width">
+        Descripción
+        <textarea formControlName="description" rows="4"></textarea>
+      </label>
+
+      <label>
+        Activa
+        <input type="checkbox" formControlName="isActive" />
+      </label>
+
+      <div class="form-actions">
+        <button type="submit" [disabled]="form.invalid || saving">
+          {{ saving ? 'Guardando…' : 'Guardar' }}
+        </button>
+        <button type="button" (click)="resetForm()" [disabled]="saving">Restablecer</button>
+      </div>
+    </form>
   `
 })
 export class AdminCategoryDetailComponent {
-  readonly categoryId: string | null;
+  private readonly categoriesApi = inject(CategoriesApi);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly fb = inject(FormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
 
-  constructor(private readonly route: ActivatedRoute) {
+  readonly form = this.fb.nonNullable.group({
+    name: ['', Validators.required],
+    slug: ['', Validators.required],
+    description: [''],
+    isActive: [true]
+  });
+
+  categoryId: string | null = null;
+  isEdit = false;
+  loading = false;
+  saving = false;
+  message: string | null = null;
+  error: string | null = null;
+
+  constructor() {
     this.categoryId = this.route.snapshot.paramMap.get('id');
+    this.isEdit = !!this.categoryId && this.categoryId !== 'new';
+    if (this.isEdit && this.categoryId) {
+      this.loadCategory(this.categoryId);
+    }
+  }
+
+  private loadCategory(id: string): void {
+    this.loading = true;
+    this.categoriesApi
+      .getById(id)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.loading = false;
+        })
+      )
+      .subscribe({
+        next: category => this.populateForm(category),
+        error: () => {
+          this.error = 'No se pudo cargar la categoría.';
+        }
+      });
+  }
+
+  private populateForm(category: CategoryViewDTO): void {
+    this.form.setValue({
+      name: category.name,
+      slug: category.slug,
+      description: category.description ?? '',
+      isActive: category.isActive
+    });
+  }
+
+  submit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.saving = true;
+    this.message = null;
+    this.error = null;
+    const rawValue = this.form.getRawValue();
+    const slug = rawValue.slug.trim() || slugify(rawValue.name);
+    const payload: CategoryCreateDTO = {
+      name: rawValue.name.trim(),
+      slug,
+      description: rawValue.description?.trim() || undefined,
+      isActive: rawValue.isActive
+    };
+
+    const request$ = this.isEdit && this.categoryId
+      ? this.categoriesApi.update(this.categoryId, payload as CategoryUpdateDTO)
+      : this.categoriesApi.create(payload);
+
+    request$
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.saving = false;
+        })
+      )
+      .subscribe({
+        next: category => {
+          this.message = 'Categoría guardada correctamente.';
+          if (!this.isEdit && category.id) {
+            this.router.navigate(['/admin/categories', category.id]);
+          }
+        },
+        error: () => {
+          this.error = 'No se pudo guardar la categoría.';
+        }
+      });
+  }
+
+  resetForm(): void {
+    if (this.isEdit && this.categoryId) {
+      this.loadCategory(this.categoryId);
+    } else {
+      this.form.reset({ name: '', slug: '', description: '', isActive: true });
+    }
   }
 }

--- a/src/app/features/admin/views/customer-detail.component.ts
+++ b/src/app/features/admin/views/customer-detail.component.ts
@@ -1,18 +1,218 @@
-import { Component } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { Component, DestroyRef, inject } from '@angular/core';
+import {
+  AbstractControl,
+  AsyncValidatorFn,
+  FormBuilder,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators
+} from '@angular/forms';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { catchError, finalize, map, of, switchMap, timer } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CustomersApi } from '../../../core/api/customers.api';
+import { CustomerCreateDTO, CustomerUpdateDTO, CustomerViewDTO } from '../../../core/models/customer';
 
 @Component({
   selector: 'app-admin-customer-detail',
   standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterModule],
   template: `
-    <h1>Customer Detail</h1>
-    <p>ID: {{ customerId }}</p>
+    <a routerLink="/admin/customers">&larr; Volver</a>
+
+    <h1>{{ isEdit ? 'Editar cliente' : 'Nuevo cliente' }}</h1>
+
+    <section *ngIf="loading" class="loading">Cargando…</section>
+    <section *ngIf="error" class="alert error">{{ error }}</section>
+    <section *ngIf="message" class="alert success">{{ message }}</section>
+
+    <form *ngIf="!loading" [formGroup]="form" (ngSubmit)="submit()" class="form-grid">
+      <label>
+        Nombres
+        <input type="text" formControlName="firstName" required />
+        <span class="error" *ngIf="form.controls.firstName.invalid && form.controls.firstName.touched">
+          Campo obligatorio.
+        </span>
+      </label>
+
+      <label>
+        Apellidos
+        <input type="text" formControlName="lastName" required />
+        <span class="error" *ngIf="form.controls.lastName.invalid && form.controls.lastName.touched">
+          Campo obligatorio.
+        </span>
+      </label>
+
+      <label>
+        Email
+        <input type="email" formControlName="email" />
+        <span class="error" *ngIf="form.controls.email.invalid && form.controls.email.touched">
+          Ingrese un correo válido.
+        </span>
+      </label>
+
+      <label>
+        Teléfono
+        <input type="tel" formControlName="phone" />
+      </label>
+
+      <label>
+        DNI
+        <input type="text" formControlName="dni" required maxlength="8" />
+        <span class="error" *ngIf="form.controls.dni.hasError('required') && form.controls.dni.touched">
+          Campo obligatorio.
+        </span>
+        <span class="error" *ngIf="form.controls.dni.hasError('pattern') && form.controls.dni.touched">
+          Debe tener 8 dígitos numéricos.
+        </span>
+        <span class="error" *ngIf="form.controls.dni.hasError('dniTaken') && form.controls.dni.touched">
+          Ya existe un cliente con este DNI.
+        </span>
+      </label>
+
+      <div class="form-actions">
+        <button type="submit" [disabled]="form.invalid || saving">
+          {{ saving ? 'Guardando…' : 'Guardar' }}
+        </button>
+        <button type="button" (click)="resetForm()" [disabled]="saving">Restablecer</button>
+      </div>
+    </form>
   `
 })
 export class AdminCustomerDetailComponent {
-  readonly customerId: string | null;
+  private readonly customersApi = inject(CustomersApi);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly fb = inject(FormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
 
-  constructor(private readonly route: ActivatedRoute) {
+  readonly form = this.fb.nonNullable.group({
+    firstName: ['', Validators.required],
+    lastName: ['', Validators.required],
+    email: ['', Validators.email],
+    phone: [''],
+    dni: [
+      '',
+      [Validators.required, Validators.pattern(/^\d{8}$/)],
+      [this.dniUniqueValidator()]
+    ]
+  });
+
+  customerId: string | null = null;
+  isEdit = false;
+  loading = false;
+  saving = false;
+  message: string | null = null;
+  error: string | null = null;
+
+  constructor() {
     this.customerId = this.route.snapshot.paramMap.get('id');
+    this.isEdit = !!this.customerId && this.customerId !== 'new';
+    if (this.isEdit && this.customerId) {
+      this.loadCustomer(this.customerId);
+    }
+  }
+
+  private loadCustomer(id: string): void {
+    this.loading = true;
+    this.customersApi
+      .getById(id)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.loading = false;
+        })
+      )
+      .subscribe({
+        next: customer => this.populateForm(customer),
+        error: () => {
+          this.error = 'No se pudo cargar el cliente.';
+        }
+      });
+  }
+
+  private populateForm(customer: CustomerViewDTO): void {
+    this.form.setValue({
+      firstName: customer.firstName,
+      lastName: customer.lastName,
+      email: customer.email ?? '',
+      phone: customer.phone ?? '',
+      dni: customer.dni
+    });
+  }
+
+  submit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.saving = true;
+    this.message = null;
+    this.error = null;
+    const rawValue = this.form.getRawValue();
+    const payload: CustomerCreateDTO = {
+      firstName: rawValue.firstName.trim(),
+      lastName: rawValue.lastName.trim(),
+      email: rawValue.email?.trim() || undefined,
+      phone: rawValue.phone?.trim() || undefined,
+      dni: rawValue.dni
+    };
+
+    const request$ = this.isEdit && this.customerId
+      ? this.customersApi.update(this.customerId, payload as CustomerUpdateDTO)
+      : this.customersApi.create(payload);
+
+    request$
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.saving = false;
+        })
+      )
+      .subscribe({
+        next: customer => {
+          this.message = 'Cliente guardado correctamente.';
+          if (!this.isEdit && customer.id) {
+            this.router.navigate(['/admin/customers', customer.id]);
+          }
+        },
+        error: () => {
+          this.error = 'No se pudo guardar el cliente.';
+        }
+      });
+  }
+
+  resetForm(): void {
+    if (this.isEdit && this.customerId) {
+      this.loadCustomer(this.customerId);
+    } else {
+      this.form.reset({ firstName: '', lastName: '', email: '', phone: '', dni: '' });
+    }
+  }
+
+  private dniUniqueValidator(): AsyncValidatorFn {
+    return (control: AbstractControl): ReturnType<AsyncValidatorFn> => {
+      if (!control.value || control.value.length !== 8) {
+        return of(null);
+      }
+      return timer(300).pipe(
+        switchMap(() =>
+          this.customersApi
+            .list({ page: 1, pageSize: 1, dni: control.value })
+            .pipe(map(response => response.items), catchError(() => of([] as CustomerViewDTO[])))
+        ),
+        map(customers => {
+          if (!customers.length) {
+            return null;
+          }
+          const found = customers[0];
+          if (this.isEdit && this.customerId && found.id === this.customerId) {
+            return null;
+          }
+          return { dniTaken: true } as ValidationErrors;
+        })
+      );
+    };
   }
 }

--- a/src/app/features/admin/views/customers-list.component.ts
+++ b/src/app/features/admin/views/customers-list.component.ts
@@ -1,10 +1,132 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { finalize } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CustomersApi } from '../../../core/api/customers.api';
+import { CustomerViewDTO } from '../../../core/models/customer';
+import { PageResponse } from '../../../core/models/pagination';
 
 @Component({
   selector: 'app-admin-customers-list',
   standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterModule],
   template: `
-    <h1>Admin Customers</h1>
+    <section class="page-header">
+      <h1>Clientes</h1>
+      <a routerLink="/admin/customers/new" class="btn">Nuevo cliente</a>
+    </section>
+
+    <form class="filters" [formGroup]="filterForm" (ngSubmit)="applyFilters()">
+      <label>
+        Buscar
+        <input type="text" formControlName="search" placeholder="Nombre, email o DNI" />
+      </label>
+
+      <div class="filter-actions">
+        <button type="submit">Aplicar</button>
+        <button type="button" (click)="resetFilters()">Limpiar</button>
+      </div>
+    </form>
+
+    <section *ngIf="error" class="alert error">{{ error }}</section>
+    <section *ngIf="loading" class="loading">Cargando clientes…</section>
+
+    <table *ngIf="!loading && customers.length" class="data-table">
+      <thead>
+        <tr>
+          <th>Nombre</th>
+          <th>Email</th>
+          <th>Teléfono</th>
+          <th>DNI</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let customer of customers">
+          <td>{{ customer.firstName }} {{ customer.lastName }}</td>
+          <td>{{ customer.email || '—' }}</td>
+          <td>{{ customer.phone || '—' }}</td>
+          <td>{{ customer.dni }}</td>
+          <td><a [routerLink]="['/admin/customers', customer.id]">Editar</a></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p *ngIf="!loading && !customers.length" class="empty-state">No hay clientes para mostrar.</p>
+
+    <nav class="pagination" *ngIf="!loading && totalPages > 1">
+      <button type="button" (click)="goToPage(page - 1)" [disabled]="page <= 1">Anterior</button>
+      <span>Página {{ page }} de {{ totalPages }}</span>
+      <button type="button" (click)="goToPage(page + 1)" [disabled]="page >= totalPages">Siguiente</button>
+    </nav>
   `
 })
-export class AdminCustomersListComponent {}
+export class AdminCustomersListComponent {
+  private readonly customersApi = inject(CustomersApi);
+  private readonly fb = inject(FormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly filterForm = this.fb.nonNullable.group({
+    search: ['']
+  });
+
+  customers: CustomerViewDTO[] = [];
+  loading = false;
+  error: string | null = null;
+  page = 1;
+  pageSize = 10;
+  totalPages = 1;
+  totalItems = 0;
+
+  constructor() {
+    this.loadCustomers(1);
+  }
+
+  applyFilters(): void {
+    this.loadCustomers(1);
+  }
+
+  resetFilters(): void {
+    this.filterForm.reset({ search: '' });
+    this.loadCustomers(1);
+  }
+
+  goToPage(page: number): void {
+    if (page < 1 || page > this.totalPages) return;
+    this.loadCustomers(page);
+  }
+
+  private loadCustomers(page: number): void {
+    this.loading = true;
+    this.error = null;
+    const { search } = this.filterForm.getRawValue();
+    this.customersApi
+      .list({
+        page,
+        pageSize: this.pageSize,
+        search: search || undefined
+      })
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.loading = false;
+        })
+      )
+      .subscribe({
+        next: response => this.handleResponse(response),
+        error: () => {
+          this.error = 'No se pudieron cargar los clientes.';
+        }
+      });
+  }
+
+  private handleResponse(response: PageResponse<CustomerViewDTO>): void {
+    this.customers = response.items;
+    this.page = response.page;
+    this.pageSize = response.pageSize;
+    this.totalPages = response.totalPages;
+    this.totalItems = response.totalItems;
+  }
+}

--- a/src/app/features/admin/views/inventory.component.ts
+++ b/src/app/features/admin/views/inventory.component.ts
@@ -1,10 +1,215 @@
-import { Component } from '@angular/core';
+import { CommonModule, DatePipe } from '@angular/common';
+import { Component, DestroyRef, computed, inject, signal } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { finalize } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { InventoryApi } from '../../../core/api/inventory.api';
+import { ProductsApi } from '../../../core/api/products.api';
+import { InventoryAdjustmentRequest, InventoryAdjustmentResponse, ProductStockResponse } from '../../../core/models/inventory';
+import { ProductViewDTO } from '../../../core/models/product';
 
 @Component({
   selector: 'app-admin-inventory',
   standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, DatePipe],
   template: `
-    <h1>Inventory Management</h1>
+    <section class="page-header">
+      <h1>Inventario</h1>
+    </section>
+
+    <section class="card">
+      <h2>Consultar stock</h2>
+      <form [formGroup]="stockForm" (ngSubmit)="onQueryStock()" class="form-grid">
+        <label>
+          Producto
+          <select formControlName="productId" required>
+            <option value="" disabled>Selecciona un producto</option>
+            <option *ngFor="let product of products()" [value]="product.id">{{ product.name }}</option>
+          </select>
+        </label>
+        <button type="submit" [disabled]="stockForm.invalid || queryingStock()">Consultar</button>
+      </form>
+
+      <p *ngIf="queryingStock()" class="loading">Consultando stock…</p>
+      <section *ngIf="stockError()" class="alert error">{{ stockError() }}</section>
+      <dl *ngIf="stockInfo()" class="stock-summary">
+        <div>
+          <dt>Stock actual</dt>
+          <dd>{{ stockInfo()!.stock }}</dd>
+        </div>
+        <div>
+          <dt>Última actualización</dt>
+          <dd>{{ stockInfo()!.updatedAt | date: 'short' }}</dd>
+        </div>
+      </dl>
+    </section>
+
+    <section class="card">
+      <h2>Ajustar stock</h2>
+      <form [formGroup]="adjustmentForm" (ngSubmit)="onSubmitAdjustment()" class="form-grid">
+        <label>
+          Producto
+          <select formControlName="productId" required>
+            <option value="" disabled>Selecciona un producto</option>
+            <option *ngFor="let product of products()" [value]="product.id">{{ product.name }}</option>
+          </select>
+        </label>
+
+        <label>
+          Cambio
+          <input type="number" formControlName="change" placeholder="Ej. 5 o -2" />
+        </label>
+
+        <label>
+          Motivo
+          <input type="text" formControlName="reason" placeholder="Opcional" />
+        </label>
+
+        <button type="submit" [disabled]="adjustmentForm.invalid || submittingAdjustment()">Registrar ajuste</button>
+      </form>
+
+      <p *ngIf="submittingAdjustment()" class="loading">Registrando ajuste…</p>
+      <section *ngIf="adjustmentMessage()" class="alert success">{{ adjustmentMessage() }}</section>
+      <section *ngIf="adjustmentError()" class="alert error">{{ adjustmentError() }}</section>
+
+      <dl *ngIf="lastAdjustment()" class="stock-summary">
+        <div>
+          <dt>Último cambio</dt>
+          <dd>{{ lastAdjustment()!.change }}</dd>
+        </div>
+        <div>
+          <dt>Registrado</dt>
+          <dd>{{ lastAdjustment()!.createdAt | date: 'short' }}</dd>
+        </div>
+        <div>
+          <dt>Por</dt>
+          <dd>{{ lastAdjustment()!.createdBy }}</dd>
+        </div>
+      </dl>
+    </section>
   `
 })
-export class AdminInventoryComponent {}
+export class AdminInventoryComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly inventoryApi = inject(InventoryApi);
+  private readonly productsApi = inject(ProductsApi);
+
+  readonly stockForm = this.fb.nonNullable.group({
+    productId: ['', Validators.required]
+  });
+
+  readonly adjustmentForm = this.fb.nonNullable.group({
+    productId: ['', Validators.required],
+    change: [0, [Validators.required]],
+    reason: ['']
+  });
+
+  private readonly productsSignal = signal<ProductViewDTO[]>([]);
+  readonly products = computed(() => this.productsSignal());
+
+  private readonly stockInfoSignal = signal<ProductStockResponse | null>(null);
+  readonly stockInfo = computed(() => this.stockInfoSignal());
+
+  private readonly queryingStockSignal = signal(false);
+  readonly queryingStock = computed(() => this.queryingStockSignal());
+
+  private readonly stockErrorSignal = signal<string | null>(null);
+  readonly stockError = computed(() => this.stockErrorSignal());
+
+  private readonly submittingAdjustmentSignal = signal(false);
+  readonly submittingAdjustment = computed(() => this.submittingAdjustmentSignal());
+
+  private readonly adjustmentMessageSignal = signal<string | null>(null);
+  readonly adjustmentMessage = computed(() => this.adjustmentMessageSignal());
+
+  private readonly adjustmentErrorSignal = signal<string | null>(null);
+  readonly adjustmentError = computed(() => this.adjustmentErrorSignal());
+
+  private readonly lastAdjustmentSignal = signal<InventoryAdjustmentResponse | null>(null);
+  readonly lastAdjustment = computed(() => this.lastAdjustmentSignal());
+
+  constructor() {
+    this.loadProducts();
+  }
+
+  onQueryStock(): void {
+    if (this.stockForm.invalid) return;
+    const { productId } = this.stockForm.getRawValue();
+    this.queryingStockSignal.set(true);
+    this.stockErrorSignal.set(null);
+    this.stockInfoSignal.set(null);
+    this.inventoryApi
+      .getProductStock(productId)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => this.queryingStockSignal.set(false))
+      )
+      .subscribe({
+        next: response => {
+          this.stockInfoSignal.set(response);
+        },
+        error: () => {
+          this.stockErrorSignal.set('No se pudo consultar el stock del producto.');
+          this.stockInfoSignal.set(null);
+        }
+      });
+  }
+
+  onSubmitAdjustment(): void {
+    if (this.adjustmentForm.invalid) return;
+    const payload = this.prepareAdjustmentPayload();
+    if (!Number.isFinite(payload.change) || payload.change === 0) {
+      this.adjustmentErrorSignal.set('El cambio debe ser distinto de cero.');
+      return;
+    }
+    this.submittingAdjustmentSignal.set(true);
+    this.adjustmentErrorSignal.set(null);
+    this.adjustmentMessageSignal.set(null);
+
+    this.inventoryApi
+      .adjust(payload)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => this.submittingAdjustmentSignal.set(false))
+      )
+      .subscribe({
+        next: response => {
+          this.lastAdjustmentSignal.set(response);
+          this.adjustmentMessageSignal.set('Ajuste registrado correctamente.');
+          const productId = this.adjustmentForm.controls.productId.value;
+          if (productId) {
+            this.inventoryApi
+              .getProductStock(productId)
+              .pipe(takeUntilDestroyed(this.destroyRef))
+              .subscribe({
+                next: stock => this.stockInfoSignal.set(stock)
+              });
+          }
+          this.adjustmentForm.patchValue({ change: 0, reason: '' });
+        },
+        error: () => {
+          this.adjustmentErrorSignal.set('No se pudo registrar el ajuste.');
+        }
+      });
+  }
+
+  private loadProducts(): void {
+    this.productsApi
+      .list({ page: 1, pageSize: 100, sort: 'name,asc', isActive: true })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: response => this.productsSignal.set(response.items),
+        error: () => this.productsSignal.set([])
+      });
+  }
+
+  private prepareAdjustmentPayload(): InventoryAdjustmentRequest {
+    const { productId, change, reason } = this.adjustmentForm.getRawValue();
+    return {
+      productId,
+      change: Number(change),
+      reason: reason?.trim() || undefined
+    };
+  }
+}

--- a/src/app/features/admin/views/product-detail.component.ts
+++ b/src/app/features/admin/views/product-detail.component.ts
@@ -1,18 +1,217 @@
-import { Component } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
+import { finalize } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ProductsApi } from '../../../core/api/products.api';
+import { CategoriesApi } from '../../../core/api/categories.api';
+import { ProductCreateDTO, ProductUpdateDTO, ProductViewDTO } from '../../../core/models/product';
+import { CategoryViewDTO } from '../../../core/models/category';
 
 @Component({
   selector: 'app-admin-product-detail',
   standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterModule],
   template: `
-    <h1>Product Detail</h1>
-    <p>ID: {{ productId }}</p>
+    <a routerLink="/admin/products">&larr; Volver</a>
+
+    <h1>{{ isEdit ? 'Editar producto' : 'Crear producto' }}</h1>
+
+    <section *ngIf="loading" class="loading">Cargando…</section>
+    <section *ngIf="error" class="alert error">{{ error }}</section>
+    <section *ngIf="message" class="alert success">{{ message }}</section>
+
+    <form *ngIf="!loading" [formGroup]="form" (ngSubmit)="submit()" class="form-grid">
+      <label>
+        Nombre
+        <input type="text" formControlName="name" required />
+        <span class="error" *ngIf="form.controls.name.invalid && form.controls.name.touched">
+          El nombre es obligatorio.
+        </span>
+      </label>
+
+      <label>
+        SKU
+        <input type="text" formControlName="sku" required />
+        <span class="error" *ngIf="form.controls.sku.invalid && form.controls.sku.touched">
+          El SKU es obligatorio.
+        </span>
+      </label>
+
+      <label>
+        Precio
+        <input type="number" step="0.01" formControlName="price" required />
+        <span class="error" *ngIf="form.controls.price.invalid && form.controls.price.touched">
+          Ingrese un precio válido.
+        </span>
+      </label>
+
+      <label>
+        Moneda
+        <input type="text" formControlName="currency" maxlength="3" required />
+      </label>
+
+      <label>
+        Categoría
+        <select formControlName="categoryId" required>
+          <option value="" disabled>Seleccione una categoría</option>
+          <option *ngFor="let category of categories" [value]="category.id">{{ category.name }}</option>
+        </select>
+        <span class="error" *ngIf="form.controls.categoryId.invalid && form.controls.categoryId.touched">
+          Seleccione una categoría.
+        </span>
+      </label>
+
+      <label class="full-width">
+        Descripción
+        <textarea formControlName="description" rows="4"></textarea>
+      </label>
+
+      <label>
+        Activo
+        <input type="checkbox" formControlName="isActive" />
+      </label>
+
+      <div class="form-actions">
+        <button type="submit" [disabled]="form.invalid || saving">
+          {{ saving ? 'Guardando…' : 'Guardar' }}
+        </button>
+        <button type="button" (click)="resetForm()" [disabled]="saving">Restablecer</button>
+      </div>
+    </form>
   `
 })
 export class AdminProductDetailComponent {
-  readonly productId: string | null;
+  private readonly productsApi = inject(ProductsApi);
+  private readonly categoriesApi = inject(CategoriesApi);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly fb = inject(FormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
 
-  constructor(private readonly route: ActivatedRoute) {
+  readonly form = this.fb.nonNullable.group({
+    name: ['', Validators.required],
+    description: [''],
+    sku: ['', Validators.required],
+    price: [0, [Validators.required, Validators.min(0)]],
+    currency: ['PEN', [Validators.required, Validators.minLength(3), Validators.maxLength(3)]],
+    categoryId: ['', Validators.required],
+    isActive: [true]
+  });
+
+  categories: CategoryViewDTO[] = [];
+  productId: string | null = null;
+  isEdit = false;
+  loading = false;
+  saving = false;
+  message: string | null = null;
+  error: string | null = null;
+
+  constructor() {
     this.productId = this.route.snapshot.paramMap.get('id');
+    this.isEdit = !!this.productId && this.productId !== 'new';
+    this.loadCategories();
+    if (this.isEdit && this.productId) {
+      this.loadProduct(this.productId);
+    }
+  }
+
+  private loadCategories(): void {
+    this.categoriesApi
+      .list({ page: 1, pageSize: 100, sort: 'name,asc' })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: response => (this.categories = response.items)
+      });
+  }
+
+  private loadProduct(id: string): void {
+    this.loading = true;
+    this.productsApi
+      .getById(id)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.loading = false;
+        })
+      )
+      .subscribe({
+        next: product => this.populateForm(product),
+        error: () => {
+          this.error = 'No se pudo cargar el producto.';
+        }
+      });
+  }
+
+  private populateForm(product: ProductViewDTO): void {
+    this.form.setValue({
+      name: product.name,
+      description: product.description ?? '',
+      sku: product.sku,
+      price: product.price,
+      currency: product.currency,
+      categoryId: product.categoryId,
+      isActive: product.isActive
+    });
+  }
+
+  submit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.saving = true;
+    this.message = null;
+    this.error = null;
+    const rawValue = this.form.getRawValue();
+    const payload: ProductCreateDTO = {
+      name: rawValue.name.trim(),
+      description: rawValue.description?.trim() || undefined,
+      sku: rawValue.sku.trim(),
+      price: Number(rawValue.price),
+      currency: rawValue.currency.trim().toUpperCase(),
+      categoryId: rawValue.categoryId,
+      isActive: rawValue.isActive
+    };
+
+    const request$ = this.isEdit && this.productId
+      ? this.productsApi.update(this.productId, payload as ProductUpdateDTO)
+      : this.productsApi.create(payload);
+
+    request$
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.saving = false;
+        })
+      )
+      .subscribe({
+        next: product => {
+          this.message = 'Producto guardado correctamente.';
+          if (!this.isEdit && product.id) {
+            this.router.navigate(['/admin/products', product.id]);
+          }
+        },
+        error: () => {
+          this.error = 'No se pudo guardar el producto.';
+        }
+      });
+  }
+
+  resetForm(): void {
+    if (this.isEdit && this.productId) {
+      this.loadProduct(this.productId);
+    } else {
+      this.form.reset({
+        name: '',
+        description: '',
+        sku: '',
+        price: 0,
+        currency: 'PEN',
+        categoryId: '',
+        isActive: true
+      });
+    }
   }
 }

--- a/src/app/features/admin/views/products-list.component.ts
+++ b/src/app/features/admin/views/products-list.component.ts
@@ -1,10 +1,175 @@
-import { Component } from '@angular/core';
+import { CommonModule, CurrencyPipe } from '@angular/common';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { finalize } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ProductsApi } from '../../../core/api/products.api';
+import { CategoriesApi } from '../../../core/api/categories.api';
+import { ProductViewDTO } from '../../../core/models/product';
+import { CategoryViewDTO } from '../../../core/models/category';
+import { PageResponse } from '../../../core/models/pagination';
 
 @Component({
   selector: 'app-admin-products-list',
   standalone: true,
+  imports: [CommonModule, RouterModule, ReactiveFormsModule, CurrencyPipe],
   template: `
-    <h1>Admin Products</h1>
+    <section class="page-header">
+      <h1>Productos</h1>
+      <a routerLink="/admin/products/new" class="btn">Crear producto</a>
+    </section>
+
+    <form class="filters" [formGroup]="filterForm" (ngSubmit)="applyFilters()">
+      <label>
+        Búsqueda
+        <input type="text" formControlName="search" placeholder="Nombre o SKU" />
+      </label>
+
+      <label>
+        Categoría
+        <select formControlName="categoryId">
+          <option value="">Todas</option>
+          <option *ngFor="let category of categories" [value]="category.id">{{ category.name }}</option>
+        </select>
+      </label>
+
+      <label>
+        Estado
+        <select formControlName="isActive">
+          <option value="">Todos</option>
+          <option value="true">Activos</option>
+          <option value="false">Inactivos</option>
+        </select>
+      </label>
+
+      <div class="filter-actions">
+        <button type="submit">Aplicar</button>
+        <button type="button" (click)="resetFilters()">Limpiar</button>
+      </div>
+    </form>
+
+    <section *ngIf="error" class="alert error">{{ error }}</section>
+    <section *ngIf="message" class="alert success">{{ message }}</section>
+    <section *ngIf="loading" class="loading">Cargando productos…</section>
+
+    <table *ngIf="!loading && products.length" class="data-table">
+      <thead>
+        <tr>
+          <th>Nombre</th>
+          <th>SKU</th>
+          <th>Precio</th>
+          <th>Categoría</th>
+          <th>Estado</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let product of products">
+          <td>{{ product.name }}</td>
+          <td>{{ product.sku }}</td>
+          <td>{{ product.price | currency: product.currency }}</td>
+          <td>{{ product.categoryName || 'Sin categoría' }}</td>
+          <td>{{ product.isActive ? 'Activo' : 'Inactivo' }}</td>
+          <td>
+            <a [routerLink]="['/admin/products', product.id]">Editar</a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p *ngIf="!loading && !products.length" class="empty-state">No hay productos para mostrar.</p>
+
+    <nav class="pagination" *ngIf="!loading && totalPages > 1">
+      <button type="button" (click)="goToPage(page - 1)" [disabled]="page <= 1">Anterior</button>
+      <span>Página {{ page }} de {{ totalPages }}</span>
+      <button type="button" (click)="goToPage(page + 1)" [disabled]="page >= totalPages">Siguiente</button>
+    </nav>
   `
 })
-export class AdminProductsListComponent {}
+export class AdminProductsListComponent {
+  private readonly productsApi = inject(ProductsApi);
+  private readonly categoriesApi = inject(CategoriesApi);
+  private readonly fb = inject(FormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly filterForm = this.fb.nonNullable.group({
+    search: [''],
+    categoryId: [''],
+    isActive: ['']
+  });
+
+  products: ProductViewDTO[] = [];
+  categories: CategoryViewDTO[] = [];
+  loading = false;
+  message: string | null = null;
+  error: string | null = null;
+  page = 1;
+  pageSize = 10;
+  totalPages = 1;
+  totalItems = 0;
+
+  constructor() {
+    this.loadCategories();
+    this.loadProducts(1);
+  }
+
+  applyFilters(): void {
+    this.loadProducts(1);
+  }
+
+  resetFilters(): void {
+    this.filterForm.reset({ search: '', categoryId: '', isActive: '' });
+    this.loadProducts(1);
+  }
+
+  goToPage(page: number): void {
+    if (page < 1 || page > this.totalPages) return;
+    this.loadProducts(page);
+  }
+
+  private loadCategories(): void {
+    this.categoriesApi
+      .list({ page: 1, pageSize: 100, sort: 'name,asc' })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: response => {
+          this.categories = response.items;
+        }
+      });
+  }
+
+  private loadProducts(page: number): void {
+    this.loading = true;
+    this.error = null;
+    const { search, categoryId, isActive } = this.filterForm.getRawValue();
+    this.productsApi
+      .list({
+        page,
+        pageSize: this.pageSize,
+        search: search || undefined,
+        categoryId: categoryId || undefined,
+        isActive: isActive ? isActive === 'true' : undefined
+      })
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.loading = false;
+        })
+      )
+      .subscribe({
+        next: response => this.handlePageResponse(response),
+        error: () => {
+          this.error = 'No se pudieron cargar los productos.';
+        }
+      });
+  }
+
+  private handlePageResponse(response: PageResponse<ProductViewDTO>): void {
+    this.products = response.items;
+    this.page = response.page;
+    this.pageSize = response.pageSize;
+    this.totalPages = response.totalPages;
+    this.totalItems = response.totalItems;
+  }
+}

--- a/src/app/features/admin/views/reservation-detail.component.ts
+++ b/src/app/features/admin/views/reservation-detail.component.ts
@@ -1,18 +1,185 @@
-import { Component } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { CommonModule, DatePipe } from '@angular/common';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import { finalize } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ReservationsApi } from '../../../core/api/reservations.api';
+import { ReservationViewDTO } from '../../../core/models/reservation';
 
 @Component({
   selector: 'app-admin-reservation-detail',
   standalone: true,
+  imports: [CommonModule, RouterModule, ReactiveFormsModule, DatePipe],
   template: `
-    <h1>Reservation Detail</h1>
-    <p>ID: {{ reservationId }}</p>
+    <a routerLink="/admin/reservations">&larr; Volver al listado</a>
+
+    <section *ngIf="loading" class="loading">Cargando reserva…</section>
+
+    <section *ngIf="error" class="alert error">{{ error }}</section>
+    <section *ngIf="message" class="alert success">{{ message }}</section>
+
+    <ng-container *ngIf="!loading && reservation">
+      <h1>Reserva {{ reservation.code }}</h1>
+
+      <dl class="detail">
+        <div>
+          <dt>Producto</dt>
+          <dd>{{ reservation.productName || reservation.productId }}</dd>
+        </div>
+        <div>
+          <dt>Cliente</dt>
+          <dd>{{ reservation.customerName || reservation.customerId }}</dd>
+        </div>
+        <div>
+          <dt>Cantidad</dt>
+          <dd>{{ reservation.quantity }}</dd>
+        </div>
+        <div>
+          <dt>Estado</dt>
+          <dd>{{ reservation.status }}</dd>
+        </div>
+        <div>
+          <dt>Reservada</dt>
+          <dd>{{ reservation.reservedAt | date: 'medium' }}</dd>
+        </div>
+        <div *ngIf="reservation.desiredPickupDate">
+          <dt>Retiro deseado</dt>
+          <dd>{{ reservation.desiredPickupDate | date }}</dd>
+        </div>
+        <div *ngIf="reservation.notes">
+          <dt>Notas</dt>
+          <dd>{{ reservation.notes }}</dd>
+        </div>
+      </dl>
+
+      <section class="actions">
+        <h2>Acciones</h2>
+        <label>
+          Crear venta al confirmar
+          <input type="checkbox" [formControl]="confirmSaleControl" />
+        </label>
+
+        <div class="action-buttons">
+          <button type="button" (click)="accept()" [disabled]="actionLoading">Aceptar</button>
+          <button type="button" (click)="confirm()" [disabled]="actionLoading">Confirmar</button>
+        </div>
+
+        <form class="cancel-form" [formGroup]="cancelForm" (ngSubmit)="cancel()">
+          <label>
+            Motivo de cancelación
+            <textarea formControlName="reason" rows="3"></textarea>
+          </label>
+          <button type="submit" [disabled]="actionLoading">Cancelar reserva</button>
+        </form>
+      </section>
+    </ng-container>
   `
 })
 export class AdminReservationDetailComponent {
-  readonly reservationId: string | null;
+  private readonly reservationsApi = inject(ReservationsApi);
+  private readonly route = inject(ActivatedRoute);
+  private readonly fb = inject(FormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
 
-  constructor(private readonly route: ActivatedRoute) {
+  readonly cancelForm = this.fb.nonNullable.group({
+    reason: ['']
+  });
+  readonly confirmSaleControl = this.fb.nonNullable.control(true);
+
+  reservationId: string | null = null;
+  reservation: ReservationViewDTO | null = null;
+  loading = false;
+  actionLoading = false;
+  message: string | null = null;
+  error: string | null = null;
+
+  constructor() {
     this.reservationId = this.route.snapshot.paramMap.get('id');
+    if (this.reservationId) {
+      this.loadReservation(this.reservationId);
+    } else {
+      this.error = 'No se encontró la reserva solicitada.';
+    }
+  }
+
+  private loadReservation(id: string): void {
+    this.loading = true;
+    this.error = null;
+    this.reservationsApi
+      .getById(id)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.loading = false;
+        })
+      )
+      .subscribe({
+        next: reservation => {
+          this.reservation = reservation;
+        },
+        error: () => {
+          this.error = 'No se pudo cargar la reserva.';
+        }
+      });
+  }
+
+  accept(): void {
+    if (!this.reservationId || !this.reservation) return;
+    if (!window.confirm(`¿Deseas aceptar la reserva ${this.reservation.code}?`)) return;
+    this.executeAction(() => this.reservationsApi.accept(this.reservationId!), 'Reserva aceptada.');
+  }
+
+  confirm(): void {
+    if (!this.reservationId || !this.reservation) return;
+    const createSale = this.confirmSaleControl.value;
+    if (
+      !window.confirm(
+        `¿Deseas confirmar la reserva ${this.reservation.code}?${createSale ? ' Se generará una venta.' : ''}`
+      )
+    ) {
+      return;
+    }
+    this.executeAction(
+      () => this.reservationsApi.confirm(this.reservationId!, createSale),
+      createSale ? 'Reserva confirmada y venta creada.' : 'Reserva confirmada.'
+    );
+  }
+
+  cancel(): void {
+    if (!this.reservationId || !this.reservation) return;
+    if (!window.confirm(`¿Deseas cancelar la reserva ${this.reservation.code}?`)) return;
+    const { reason } = this.cancelForm.getRawValue();
+    this.executeAction(
+      () => this.reservationsApi.cancel(this.reservationId!, reason ? { reason } : {}),
+      'Reserva cancelada.'
+    );
+  }
+
+  private executeAction(
+    requestFactory: () => ReturnType<ReservationsApi['accept']>,
+    successMessage: string
+  ): void {
+    this.actionLoading = true;
+    this.message = null;
+    this.error = null;
+    requestFactory()
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.actionLoading = false;
+        })
+      )
+      .subscribe({
+        next: () => {
+          this.message = successMessage;
+          if (this.reservationId) {
+            this.loadReservation(this.reservationId);
+          }
+        },
+        error: () => {
+          this.error = 'No fue posible completar la acción.';
+        }
+      });
   }
 }

--- a/src/app/features/admin/views/reservations-list.component.ts
+++ b/src/app/features/admin/views/reservations-list.component.ts
@@ -1,10 +1,250 @@
-import { Component } from '@angular/core';
+import { CommonModule, DatePipe } from '@angular/common';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { finalize } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ReservationsApi } from '../../../core/api/reservations.api';
+import { ReservationViewDTO } from '../../../core/models/reservation';
+import { PageResponse } from '../../../core/models/pagination';
 
 @Component({
   selector: 'app-admin-reservations-list',
   standalone: true,
+  imports: [CommonModule, RouterModule, ReactiveFormsModule, DatePipe],
   template: `
-    <h1>Admin Reservations</h1>
+    <section class="page-header">
+      <h1>Reservas</h1>
+    </section>
+
+    <form class="filters" [formGroup]="filterForm" (ngSubmit)="onFilter()">
+      <label>
+        Búsqueda
+        <input type="text" formControlName="search" placeholder="Código, cliente o producto" />
+      </label>
+
+      <label>
+        Estado
+        <select formControlName="status">
+          <option value="">Todos</option>
+          <option *ngFor="let option of statusOptions" [value]="option.value">{{ option.label }}</option>
+        </select>
+      </label>
+
+      <div class="filter-actions">
+        <button type="submit">Aplicar filtros</button>
+        <button type="button" (click)="clearFilters()">Limpiar</button>
+      </div>
+    </form>
+
+    <section *ngIf="message" class="alert success">{{ message }}</section>
+    <section *ngIf="error" class="alert error">{{ error }}</section>
+
+    <section *ngIf="loading" class="loading">Cargando reservas…</section>
+
+    <table *ngIf="!loading && reservations.length" class="data-table">
+      <thead>
+        <tr>
+          <th>Código</th>
+          <th>Producto</th>
+          <th>Cliente</th>
+          <th>Cantidad</th>
+          <th>Estado</th>
+          <th>Reservada</th>
+          <th>Acciones</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let reservation of reservations">
+          <td>{{ reservation.code }}</td>
+          <td>{{ reservation.productName || reservation.productId }}</td>
+          <td>{{ reservation.customerName || reservation.customerId }}</td>
+          <td>{{ reservation.quantity }}</td>
+          <td>{{ reservation.status }}</td>
+          <td>{{ reservation.reservedAt | date: 'short' }}</td>
+          <td>
+            <a [routerLink]="['/admin/reservations', reservation.id]">Ver detalle</a>
+            <button type="button" (click)="acceptReservation(reservation)" [disabled]="isActionInFlight(reservation.id)">
+              Aceptar
+            </button>
+            <button type="button" (click)="confirmReservation(reservation, true)" [disabled]="isActionInFlight(reservation.id)">
+              Confirmar + venta
+            </button>
+            <button type="button" (click)="confirmReservation(reservation, false)" [disabled]="isActionInFlight(reservation.id)">
+              Confirmar sin venta
+            </button>
+            <button type="button" (click)="cancelReservation(reservation)" [disabled]="isActionInFlight(reservation.id)">
+              Cancelar
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p *ngIf="!loading && !reservations.length" class="empty-state">No se encontraron reservas con los filtros seleccionados.</p>
+
+    <nav class="pagination" *ngIf="!loading && totalPages > 1">
+      <button type="button" (click)="goToPage(page - 1)" [disabled]="page <= 1">Anterior</button>
+      <span>Página {{ page }} de {{ totalPages }}</span>
+      <button type="button" (click)="goToPage(page + 1)" [disabled]="page >= totalPages">Siguiente</button>
+    </nav>
   `
 })
-export class AdminReservationsListComponent {}
+export class AdminReservationsListComponent {
+  private readonly reservationsApi = inject(ReservationsApi);
+  private readonly fb = inject(FormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly filterForm = this.fb.nonNullable.group({
+    search: [''],
+    status: ['']
+  });
+
+  readonly statusOptions: { value: string; label: string }[] = [
+    { value: 'pending', label: 'Pendiente' },
+    { value: 'confirmed', label: 'Confirmada' },
+    { value: 'cancelled', label: 'Cancelada' },
+    { value: 'picked_up', label: 'Retirada' }
+  ];
+
+  reservations: ReservationViewDTO[] = [];
+  page = 1;
+  pageSize = 10;
+  totalPages = 1;
+  totalItems = 0;
+  loading = false;
+  message: string | null = null;
+  error: string | null = null;
+  private actionInFlight: string | null = null;
+
+  constructor() {
+    this.loadReservations(1);
+  }
+
+  onFilter(): void {
+    this.loadReservations(1);
+  }
+
+  clearFilters(): void {
+    this.filterForm.reset({ search: '', status: '' });
+    this.loadReservations(1);
+  }
+
+  goToPage(page: number): void {
+    if (page < 1 || page > this.totalPages) return;
+    this.loadReservations(page);
+  }
+
+  isActionInFlight(reservationId: string): boolean {
+    return this.actionInFlight === reservationId;
+  }
+
+  private loadReservations(page: number): void {
+    this.loading = true;
+    this.error = null;
+    const { search, status } = this.filterForm.getRawValue();
+    this.reservationsApi
+      .list({
+        page,
+        pageSize: this.pageSize,
+        search: search || undefined,
+        status: status || undefined
+      })
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.loading = false;
+        })
+      )
+      .subscribe({
+        next: response => this.handlePageResponse(response),
+        error: () => {
+          this.error = 'No se pudieron cargar las reservas.';
+        }
+      });
+  }
+
+  private handlePageResponse(response: PageResponse<ReservationViewDTO>): void {
+    this.reservations = response.items;
+    this.totalItems = response.totalItems;
+    this.page = response.page;
+    this.pageSize = response.pageSize;
+    this.totalPages = response.totalPages;
+  }
+
+  private setActionFeedback(message: string | null, error: string | null): void {
+    this.message = message;
+    this.error = error;
+  }
+
+  acceptReservation(reservation: ReservationViewDTO): void {
+    if (!reservation.id) return;
+    if (!window.confirm(`¿Confirmas aceptar la reserva ${reservation.code}?`)) {
+      return;
+    }
+    this.executeAction(reservation.id, () => this.reservationsApi.accept(reservation.id), () => {
+      this.setActionFeedback(`Reserva ${reservation.code} aceptada correctamente.`, null);
+      this.loadReservations(this.page);
+    });
+  }
+
+  confirmReservation(reservation: ReservationViewDTO, createSale: boolean): void {
+    if (!reservation.id) return;
+    if (
+      !window.confirm(
+        `¿Confirmas la reserva ${reservation.code}?${createSale ? ' Se generará una venta.' : ''}`
+      )
+    ) {
+      return;
+    }
+    this.executeAction(
+      reservation.id,
+      () => this.reservationsApi.confirm(reservation.id, createSale),
+      () => {
+        this.setActionFeedback(
+          `Reserva ${reservation.code} confirmada${createSale ? ' y venta creada' : ''}.`,
+          null
+        );
+        this.loadReservations(this.page);
+      }
+    );
+  }
+
+  cancelReservation(reservation: ReservationViewDTO): void {
+    if (!reservation.id) return;
+    const reason = window.prompt('Motivo de cancelación (opcional):') ?? undefined;
+    if (!window.confirm(`¿Quieres cancelar la reserva ${reservation.code}?`)) {
+      return;
+    }
+    this.executeAction(
+      reservation.id,
+      () => this.reservationsApi.cancel(reservation.id, reason ? { reason } : {}),
+      () => {
+        this.setActionFeedback(`Reserva ${reservation.code} cancelada.`, null);
+        this.loadReservations(this.page);
+      }
+    );
+  }
+
+  private executeAction(
+    reservationId: string,
+    requestFactory: () => ReturnType<ReservationsApi['accept']>,
+    onSuccess: () => void
+  ): void {
+    this.actionInFlight = reservationId;
+    this.setActionFeedback(null, null);
+    requestFactory()
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.actionInFlight = null;
+        })
+      )
+      .subscribe({
+        next: () => onSuccess(),
+        error: () => {
+          this.setActionFeedback(null, 'No se pudo completar la acción sobre la reserva.');
+        }
+      });
+  }
+}

--- a/src/app/features/admin/views/sale-detail.component.ts
+++ b/src/app/features/admin/views/sale-detail.component.ts
@@ -1,18 +1,101 @@
-import { Component } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { CommonModule, CurrencyPipe, DatePipe } from '@angular/common';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { ActivatedRoute, RouterModule } from '@angular/router';
+import { finalize } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { SalesApi } from '../../../core/api/sales.api';
+import { SaleViewDTO } from '../../../core/models/sale';
 
 @Component({
   selector: 'app-admin-sale-detail',
   standalone: true,
+  imports: [CommonModule, RouterModule, DatePipe, CurrencyPipe],
   template: `
-    <h1>Sale Detail</h1>
-    <p>ID: {{ saleId }}</p>
+    <a routerLink="/admin/sales">&larr; Volver</a>
+
+    <h1>Detalle de venta</h1>
+
+    <section *ngIf="loading" class="loading">Cargando venta…</section>
+    <section *ngIf="error" class="alert error">{{ error }}</section>
+
+    <article *ngIf="!loading && sale" class="card">
+      <header>
+        <h2>Venta #{{ sale.id }}</h2>
+        <p>Creada el {{ sale.createdAt | date: 'medium' }} por {{ sale.createdBy }}</p>
+      </header>
+
+      <dl class="sale-summary">
+        <div>
+          <dt>Reserva asociada</dt>
+          <dd>{{ sale.reservationId || 'N/A' }}</dd>
+        </div>
+        <div>
+          <dt>Total</dt>
+          <dd>{{ sale.total | currency: sale.currency }}</dd>
+        </div>
+      </dl>
+
+      <section>
+        <h3>Ítems</h3>
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th>Producto</th>
+              <th>Cantidad</th>
+              <th>Precio unitario</th>
+              <th>Subtotal</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr *ngFor="let item of sale.items">
+              <td>{{ item.productId }}</td>
+              <td>{{ item.quantity }}</td>
+              <td>{{ item.unitPrice | currency: item.currency }}</td>
+              <td>{{ (item.unitPrice * item.quantity) | currency: item.currency }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </article>
   `
 })
 export class AdminSaleDetailComponent {
-  readonly saleId: string | null;
+  private readonly route = inject(ActivatedRoute);
+  private readonly salesApi = inject(SalesApi);
+  private readonly destroyRef = inject(DestroyRef);
 
-  constructor(private readonly route: ActivatedRoute) {
-    this.saleId = this.route.snapshot.paramMap.get('id');
+  readonly saleId = this.route.snapshot.paramMap.get('id');
+
+  sale: SaleViewDTO | null = null;
+  loading = false;
+  error: string | null = null;
+
+  constructor() {
+    if (this.saleId) {
+      this.loadSale(this.saleId);
+    } else {
+      this.error = 'Identificador de venta no válido.';
+    }
+  }
+
+  private loadSale(id: string): void {
+    this.loading = true;
+    this.error = null;
+    this.salesApi
+      .getById(id)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.loading = false;
+        })
+      )
+      .subscribe({
+        next: sale => {
+          this.sale = sale;
+        },
+        error: () => {
+          this.error = 'No se pudo cargar la venta solicitada.';
+        }
+      });
   }
 }

--- a/src/app/features/admin/views/sales-list.component.ts
+++ b/src/app/features/admin/views/sales-list.component.ts
@@ -1,10 +1,299 @@
-import { Component } from '@angular/core';
+import { CommonModule, CurrencyPipe, DatePipe } from '@angular/common';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { FormArray, FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { finalize } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { SalesApi } from '../../../core/api/sales.api';
+import { ProductsApi } from '../../../core/api/products.api';
+import { SaleCreateDTO, SaleDTO } from '../../../core/models/sale';
+import { ProductViewDTO } from '../../../core/models/product';
+
+function createSaleItemGroup(fb: FormBuilder) {
+  return fb.nonNullable.group({
+    productId: ['', Validators.required],
+    quantity: [1, [Validators.required, Validators.min(1)]],
+    unitPrice: [0, [Validators.required, Validators.min(0)]],
+    currency: ['PEN', [Validators.required, Validators.minLength(3), Validators.maxLength(3)]]
+  });
+}
+
+type SaleItemFormGroup = ReturnType<typeof createSaleItemGroup>;
 
 @Component({
   selector: 'app-admin-sales-list',
   standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterModule, CurrencyPipe, DatePipe],
   template: `
-    <h1>Sales</h1>
+    <section class="page-header">
+      <h1>Ventas</h1>
+    </section>
+
+    <section class="card">
+      <h2>Crear venta</h2>
+      <form [formGroup]="saleForm" (ngSubmit)="onCreateSale()" class="form-grid">
+        <label class="full-width">
+          ID de reserva (opcional)
+          <input type="text" formControlName="reservationId" placeholder="Reserva relacionada" />
+        </label>
+
+        <div formArrayName="items" class="full-width item-list">
+          <article *ngFor="let item of saleItems.controls; let i = index" [formGroupName]="i" class="item-row">
+            <label>
+              Producto
+              <select formControlName="productId" required>
+                <option value="" disabled>Selecciona un producto</option>
+                <option *ngFor="let product of products" [value]="product.id">{{ product.name }}</option>
+              </select>
+            </label>
+
+            <label>
+              Cantidad
+              <input type="number" formControlName="quantity" min="1" />
+            </label>
+
+            <label>
+              Precio unitario
+              <input type="number" step="0.01" formControlName="unitPrice" min="0" />
+            </label>
+
+            <label>
+              Moneda
+              <input type="text" maxlength="3" formControlName="currency" />
+            </label>
+
+            <button type="button" class="link" (click)="removeItem(i)" *ngIf="saleItems.length > 1">Eliminar</button>
+          </article>
+        </div>
+
+        <div class="form-actions full-width">
+          <button type="button" (click)="addItem()">Agregar ítem</button>
+          <button type="submit" [disabled]="saleForm.invalid || creatingSale">{{ creatingSale ? 'Creando…' : 'Crear venta' }}</button>
+        </div>
+      </form>
+
+      <section *ngIf="createMessage" class="alert success">{{ createMessage }}</section>
+      <section *ngIf="createError" class="alert error">{{ createError }}</section>
+    </section>
+
+    <section class="card">
+      <h2>Buscar ventas</h2>
+      <form [formGroup]="filterForm" (ngSubmit)="onFilterSales()" class="form-grid">
+        <label>
+          Desde
+          <input type="date" formControlName="start" />
+        </label>
+        <label>
+          Hasta
+          <input type="date" formControlName="end" />
+        </label>
+        <button type="submit" [disabled]="filterForm.invalid || loadingSales">Buscar</button>
+      </form>
+
+      <section *ngIf="listError" class="alert error">{{ listError }}</section>
+      <p *ngIf="loadingSales" class="loading">Cargando ventas…</p>
+
+      <table *ngIf="!loadingSales && sales.length" class="data-table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Reserva</th>
+            <th>Total</th>
+            <th>Creada</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let sale of sales">
+            <td>{{ sale.id }}</td>
+            <td>{{ sale.reservationId || '—' }}</td>
+            <td>{{ sale.total | currency: sale.currency }}</td>
+            <td>{{ sale.createdAt | date: 'short' }}</td>
+            <td><a [routerLink]="['/admin/sales', sale.id]">Ver detalle</a></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p *ngIf="!loadingSales && !sales.length" class="empty-state">No se encontraron ventas para el rango indicado.</p>
+    </section>
   `
 })
-export class AdminSalesListComponent {}
+export class AdminSalesListComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly salesApi = inject(SalesApi);
+  private readonly productsApi = inject(ProductsApi);
+
+  readonly filterForm = this.fb.nonNullable.group({
+    start: [this.formatDate(this.daysAgo(7)), Validators.required],
+    end: [this.formatDate(new Date()), Validators.required]
+  });
+
+  readonly saleForm = this.fb.nonNullable.group({
+    reservationId: [''],
+    items: this.fb.array<SaleItemFormGroup>([createSaleItemGroup(this.fb)])
+  });
+
+  products: ProductViewDTO[] = [];
+  sales: SaleDTO[] = [];
+  loadingSales = false;
+  creatingSale = false;
+  listError: string | null = null;
+  createMessage: string | null = null;
+  createError: string | null = null;
+
+  constructor() {
+    this.loadProducts();
+    this.loadSales();
+  }
+
+  get saleItems(): FormArray<SaleItemFormGroup> {
+    return this.saleForm.controls.items;
+  }
+
+  addItem(): void {
+    this.saleItems.push(createSaleItemGroup(this.fb));
+  }
+
+  removeItem(index: number): void {
+    if (this.saleItems.length <= 1) return;
+    this.saleItems.removeAt(index);
+  }
+
+  onFilterSales(): void {
+    if (this.filterForm.invalid) {
+      this.filterForm.markAllAsTouched();
+      return;
+    }
+    this.loadSales();
+  }
+
+  onCreateSale(): void {
+    if (this.saleForm.invalid) {
+      this.saleForm.markAllAsTouched();
+      return;
+    }
+
+    const payload = this.buildSalePayload();
+    if (!payload.items.length) {
+      this.createError = 'Agrega al menos un ítem a la venta.';
+      return;
+    }
+
+    const hasInvalidItem = payload.items.some(
+      item => !item.productId || item.quantity <= 0 || !Number.isFinite(item.unitPrice) || item.unitPrice < 0
+    );
+    if (hasInvalidItem) {
+      this.createError = 'Revisa los datos de los ítems antes de crear la venta.';
+      return;
+    }
+
+    this.creatingSale = true;
+    this.createError = null;
+    this.createMessage = null;
+
+    this.salesApi
+      .create(payload)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.creatingSale = false;
+        })
+      )
+      .subscribe({
+        next: sale => {
+          this.createMessage = 'Venta creada correctamente.';
+          this.resetSaleForm();
+          this.loadSales();
+        },
+        error: () => {
+          this.createError = 'No se pudo crear la venta.';
+        }
+      });
+  }
+
+  private loadSales(): void {
+    const { start, end } = this.filterForm.getRawValue();
+    if (!start || !end) {
+      this.listError = 'Selecciona el rango de fechas a consultar.';
+      this.sales = [];
+      return;
+    }
+
+    if (new Date(start) > new Date(end)) {
+      this.listError = 'La fecha inicial debe ser anterior o igual a la final.';
+      this.sales = [];
+      return;
+    }
+
+    this.loadingSales = true;
+    this.listError = null;
+
+    this.salesApi
+      .listByDateRange(start, end)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.loadingSales = false;
+        })
+      )
+      .subscribe({
+        next: sales => {
+          this.sales = sales;
+        },
+        error: () => {
+          this.listError = 'No se pudieron cargar las ventas.';
+          this.sales = [];
+        }
+      });
+  }
+
+  private loadProducts(): void {
+    this.productsApi
+      .list({ page: 1, pageSize: 100, sort: 'name,asc', isActive: true })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: response => (this.products = response.items),
+        error: () => (this.products = [])
+      });
+  }
+
+  private buildSalePayload(): SaleCreateDTO {
+    const { reservationId } = this.saleForm.getRawValue();
+    const items = this.saleItems.controls.map(control => {
+      const value = control.getRawValue();
+      return {
+        productId: value.productId,
+        quantity: Number(value.quantity),
+        unitPrice: Number(value.unitPrice),
+        currency: value.currency.trim().toUpperCase()
+      };
+    });
+
+    return {
+      reservationId: reservationId?.trim() || undefined,
+      items: items.filter(item => !!item.productId)
+    };
+  }
+
+  private resetSaleForm(): void {
+    this.saleForm.reset({ reservationId: '' });
+    while (this.saleItems.length) {
+      this.saleItems.removeAt(0);
+    }
+    this.saleItems.push(createSaleItemGroup(this.fb));
+  }
+
+  private daysAgo(days: number): Date {
+    const today = new Date();
+    today.setDate(today.getDate() - days);
+    return today;
+  }
+
+  private formatDate(date: Date): string {
+    const year = date.getFullYear();
+    const month = `${date.getMonth() + 1}`.padStart(2, '0');
+    const day = `${date.getDate()}`.padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+}

--- a/src/app/features/public/views/reserve.component.ts
+++ b/src/app/features/public/views/reserve.component.ts
@@ -1,10 +1,235 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, inject, signal } from '@angular/core';
+import { AbstractControl, FormBuilder, ReactiveFormsModule, ValidatorFn, Validators } from '@angular/forms';
+import { finalize } from 'rxjs';
+import { PublicProductsApi, PublicReservationsApi } from '../../../core/api';
+import {
+  PublicProductView,
+  PublicReservationCreatedResponse,
+  PublicReservationCreateRequest
+} from '../../../core/models';
 
 @Component({
   selector: 'app-reserve',
   standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
   template: `
-    <h1>Reserve Product</h1>
+    <section class="reserve">
+      <h1>Reserva con DNI</h1>
+
+      <p class="reserve__intro">
+        Completa tus datos y selecciona el producto para generar una reserva. Todos los campos son
+        obligatorios salvo observaciones.
+      </p>
+
+      <form [formGroup]="form" (ngSubmit)="submit()" class="reserve__form" novalidate>
+        <fieldset [disabled]="loading()">
+          <div class="reserve__field">
+            <label for="dni">DNI</label>
+            <input
+              id="dni"
+              type="text"
+              formControlName="dni"
+              maxlength="8"
+              inputmode="numeric"
+              placeholder="12345678"
+              required
+            />
+            <small class="error" *ngIf="hasError('dni', 'required')">El DNI es obligatorio.</small>
+            <small class="error" *ngIf="hasError('dni', 'pattern')">Debe contener 8 dígitos.</small>
+          </div>
+
+          <div class="reserve__field">
+            <label for="name">Nombre completo</label>
+            <input id="name" type="text" formControlName="customerName" required />
+            <small class="error" *ngIf="hasError('customerName', 'required')">
+              El nombre es obligatorio.
+            </small>
+          </div>
+
+          <div class="reserve__field">
+            <label for="email">Correo electrónico</label>
+            <input id="email" type="email" formControlName="customerEmail" required />
+            <small class="error" *ngIf="hasError('customerEmail', 'required')">
+              El correo es obligatorio.
+            </small>
+            <small class="error" *ngIf="hasError('customerEmail', 'email')">
+              Ingresa un correo válido.
+            </small>
+          </div>
+
+          <div class="reserve__field">
+            <label for="phone">Teléfono</label>
+            <input id="phone" type="tel" formControlName="customerPhone" required />
+            <small class="error" *ngIf="hasError('customerPhone', 'required')">
+              El teléfono es obligatorio.
+            </small>
+          </div>
+
+          <div class="reserve__field">
+            <label for="product">Producto</label>
+            <select id="product" formControlName="productId" required>
+              <option value="" disabled>Selecciona un producto</option>
+              <option *ngFor="let product of products()" [value]="product.id">
+                {{ product.name }}
+              </option>
+            </select>
+            <small class="error" *ngIf="hasError('productId', 'required')">
+              Debes seleccionar un producto.
+            </small>
+          </div>
+
+          <div class="reserve__field">
+            <label for="quantity">Cantidad</label>
+            <input id="quantity" type="number" min="1" formControlName="quantity" required />
+            <small class="error" *ngIf="hasError('quantity', 'required')">
+              La cantidad es obligatoria.
+            </small>
+            <small class="error" *ngIf="hasError('quantity', 'min')">
+              Debe ser al menos 1.
+            </small>
+          </div>
+
+          <div class="reserve__field">
+            <label for="pickup">Fecha de retiro</label>
+            <input id="pickup" type="date" formControlName="desiredPickupDate" [min]="today" />
+            <small class="error" *ngIf="hasError('desiredPickupDate', 'minDate')">
+              La fecha debe ser desde hoy en adelante.
+            </small>
+          </div>
+
+          <div class="reserve__field">
+            <label for="notes">Observaciones</label>
+            <textarea id="notes" formControlName="notes" rows="3"></textarea>
+          </div>
+
+          <button type="submit" [disabled]="form.invalid || loading()">Reservar</button>
+        </fieldset>
+      </form>
+
+      <p class="reserve__status" *ngIf="error()">{{ error() }}</p>
+      <p class="reserve__status" *ngIf="!error() && !loading() && products().length === 0">
+        No hay productos disponibles para reserva en este momento.
+      </p>
+
+      <section class="reserve__confirmation" *ngIf="confirmation() as result">
+        <h2>Reserva creada correctamente</h2>
+        <p><strong>ID:</strong> {{ result.reservationId }}</p>
+        <p><strong>Código:</strong> {{ result.code }}</p>
+        <p *ngIf="result.expiresAt"><strong>Vence:</strong> {{ result.expiresAt | date }}</p>
+      </section>
+    </section>
   `
 })
-export class ReserveComponent {}
+export class ReserveComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly publicReservationsApi = inject(PublicReservationsApi);
+  private readonly publicProductsApi = inject(PublicProductsApi);
+
+  readonly today = new Date().toISOString().split('T')[0];
+
+  readonly form = this.fb.nonNullable.group({
+    dni: ['', [Validators.required, Validators.pattern(/^\d{8}$/)]],
+    customerName: ['', Validators.required],
+    customerEmail: ['', [Validators.required, Validators.email]],
+    customerPhone: ['', Validators.required],
+    productId: ['', Validators.required],
+    quantity: [1, [Validators.required, Validators.min(1)]],
+    desiredPickupDate: ['', this.minDateValidator()],
+    notes: ['']
+  });
+
+  readonly loading = signal(false);
+  readonly error = signal('');
+  readonly products = signal<PublicProductView[]>([]);
+  readonly confirmation = signal<PublicReservationCreatedResponse | null>(null);
+
+  constructor() {
+    this.fetchProducts();
+  }
+
+  hasError(controlName: keyof typeof this.form.controls, errorCode: string): boolean {
+    const control = this.form.controls[controlName];
+    return control.touched && control.hasError(errorCode);
+  }
+
+  submit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const raw = this.form.getRawValue();
+    const request: PublicReservationCreateRequest = {
+      productId: raw.productId,
+      quantity: raw.quantity,
+      desiredPickupDate: raw.desiredPickupDate ? new Date(raw.desiredPickupDate).toISOString() : undefined,
+      customerDocument: raw.dni,
+      customerName: raw.customerName,
+      customerEmail: raw.customerEmail,
+      customerPhone: raw.customerPhone,
+      notes: raw.notes || undefined
+    };
+
+    this.loading.set(true);
+    this.error.set('');
+    this.confirmation.set(null);
+
+    this.publicReservationsApi
+      .create(request)
+      .pipe(finalize(() => this.loading.set(false)))
+      .subscribe({
+        next: (response) => {
+          this.confirmation.set(response);
+          this.form.reset({
+            dni: '',
+            customerName: '',
+            customerEmail: '',
+            customerPhone: '',
+            productId: '',
+            quantity: 1,
+            desiredPickupDate: '',
+            notes: ''
+          });
+        },
+        error: () => {
+          this.error.set('No se pudo crear la reserva. Intenta nuevamente.');
+        }
+      });
+  }
+
+  private fetchProducts(): void {
+    this.loading.set(true);
+    this.error.set('');
+
+    this.publicProductsApi
+      .list({ page: 1, pageSize: 50 })
+      .pipe(finalize(() => this.loading.set(false)))
+      .subscribe({
+        next: (response) => {
+          this.products.set(response.items);
+        },
+        error: () => {
+          this.error.set('No se pudieron cargar los productos.');
+        }
+      });
+  }
+
+  private minDateValidator(): ValidatorFn {
+    return (control: AbstractControl): Record<string, boolean> | null => {
+      if (!control.value) {
+        return null;
+      }
+
+      const selected = new Date(control.value);
+      const today = new Date(this.today);
+
+      if (selected < today) {
+        return { minDate: true };
+      }
+
+      return null;
+    };
+  }
+
+}


### PR DESCRIPTION
## Summary
- add the admin inventory view to consult stock levels, register adjustments, and display the last change feedback
- implement the admin sales dashboard with a typed sale creation form, date-range filtering, and links to sale details
- hydrate the sale detail screen with API data and full item breakdown

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5a4f0b0f48329bcb638997f5425c1