### PR TITLE
Add admin navigation layout and global styles

### DIFF
--- a/src/app/features/admin/adminLayout.component.css
+++ b/src/app/features/admin/adminLayout.component.css
@@ -1,0 +1,162 @@
+:host {
+  display: block;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #0f172a 0%, #111c3d 40%, #0f172a 100%);
+}
+
+.admin-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.admin-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 64px;
+  padding: 0 2rem;
+  background: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(12px);
+  color: #f8fafc;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.admin-topbar__brand {
+  font-size: 1.15rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.admin-topbar__user {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-weight: 500;
+}
+
+.admin-topbar__name {
+  max-width: 220px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.admin-shell__body {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+.admin-sidebar {
+  width: 260px;
+  padding: 2rem 1.5rem;
+  background: rgba(15, 23, 42, 0.92);
+  backdrop-filter: blur(16px);
+  color: #e2e8f0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  border-right: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.admin-sidebar__title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(226, 232, 240, 0.72);
+}
+
+.admin-sidebar__menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.admin-sidebar__link {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  color: inherit;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background 0.2s ease, transform 0.2s ease, color 0.2s ease;
+}
+
+.admin-sidebar__link::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.35);
+  transition: background 0.2s ease;
+}
+
+.admin-sidebar__link:hover {
+  background: rgba(148, 163, 184, 0.18);
+  color: #fff;
+}
+
+.admin-sidebar__link:hover::before {
+  background: rgba(226, 232, 240, 0.85);
+}
+
+.admin-sidebar__link.active {
+  background: linear-gradient(135deg, #2563eb 0%, #38bdf8 100%);
+  color: #fff;
+  box-shadow: 0 18px 40px -18px rgba(56, 189, 248, 0.6);
+}
+
+.admin-sidebar__link.active::before {
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.admin-content {
+  flex: 1;
+  padding: 2.5rem;
+  background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.08), transparent 55%),
+    radial-gradient(circle at top right, rgba(6, 182, 212, 0.08), transparent 50%),
+    #f8fafc;
+  overflow-y: auto;
+}
+
+.admin-content > *:first-child {
+  margin-top: 0;
+}
+
+.admin-content button[type='button'] {
+  color: #0f172a;
+}
+
+@media (max-width: 960px) {
+  .admin-shell__body {
+    flex-direction: column;
+  }
+
+  .admin-sidebar {
+    width: 100%;
+    flex-direction: row;
+    align-items: center;
+    gap: 1rem;
+    overflow-x: auto;
+    padding: 1rem 1.5rem;
+  }
+
+  .admin-sidebar__menu {
+    flex-direction: row;
+  }
+
+  .admin-sidebar__link {
+    padding: 0.65rem 0.95rem;
+  }
+}

--- a/src/app/features/admin/adminLayout.component.ts
+++ b/src/app/features/admin/adminLayout.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit, inject } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { Observable } from 'rxjs';
 import { AuthService } from '../../core/auth/auth.service';
 import { MeResponse } from '../../core/models/auth';
@@ -8,24 +8,57 @@ import { MeResponse } from '../../core/models/auth';
 @Component({
   selector: 'app-admin-layout',
   standalone: true,
-  imports: [CommonModule, RouterOutlet],
+  imports: [CommonModule, RouterOutlet, RouterLink, RouterLinkActive],
+  styleUrls: ['./adminLayout.component.css'],
   template: `
-    <header class="admin-topbar">
-      <div class="admin-topbar__brand">Panel de administracion</div>
-      <div class="admin-topbar__user" *ngIf="currentUser$ | async as user">
-        <span class="admin-topbar__name">{{ user.displayName || user.email }}</span>
-        <button type="button" (click)="logout()">Cerrar sesion</button>
+    <div class="admin-shell">
+      <header class="admin-topbar">
+        <div class="admin-topbar__brand">Panel de administración</div>
+        <div class="admin-topbar__user" *ngIf="currentUser$ | async as user">
+          <span class="admin-topbar__name">{{ user.displayName || user.email }}</span>
+          <button type="button" (click)="logout()">Cerrar sesion</button>
+        </div>
+      </header>
+
+      <div class="admin-shell__body">
+        <nav class="admin-sidebar" aria-label="Secciones de administración">
+          <h2 class="admin-sidebar__title">Menú</h2>
+          <ul class="admin-sidebar__menu">
+            <li *ngFor="let link of navLinks">
+              <a
+                class="admin-sidebar__link"
+                [routerLink]="link.path"
+                [routerLinkActiveOptions]="{ exact: link.exact }"
+                routerLinkActive="active"
+              >
+                {{ link.label }}
+              </a>
+            </li>
+          </ul>
+        </nav>
+
+        <main class="admin-content">
+          <router-outlet />
+        </main>
       </div>
-    </header>
-    <main class="admin-content">
-      <router-outlet />
-    </main>
+    </div>
   `
 })
 export class AdminLayoutComponent implements OnInit {
   private readonly auth = inject(AuthService);
 
   currentUser$: Observable<MeResponse | null> = this.auth.currentUser$;
+
+  readonly navLinks: Array<{ label: string; path: string | string[]; exact: boolean }> = [
+    { label: 'Dashboard', path: '/admin', exact: true },
+    { label: 'Reservas', path: '/admin/reservations', exact: false },
+    { label: 'Productos', path: '/admin/products', exact: false },
+    { label: 'Categorías', path: '/admin/categories', exact: false },
+    { label: 'Clientes', path: '/admin/customers', exact: false },
+    { label: 'Inventario', path: '/admin/inventory', exact: false },
+    { label: 'Ventas', path: '/admin/sales', exact: false },
+    { label: 'Reportes', path: '/admin/reports', exact: false }
+  ];
 
   ngOnInit(): void {
     this.auth.me().subscribe({ error: () => this.auth.logout() });

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,398 @@
-/* You can add global styles to this file, and also import other style files */
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #f8fafc;
+  color: #0f172a;
+  line-height: 1.5;
+}
+
+a {
+  color: #2563eb;
+  font-weight: 500;
+  text-decoration: none;
+  transition: color 0.2s ease, text-decoration-color 0.2s ease;
+}
+
+a:hover {
+  color: #1d4ed8;
+  text-decoration: underline;
+}
+
+a.link {
+  color: #ef4444;
+  font-weight: 600;
+}
+
+a.link:hover {
+  color: #b91c1c;
+}
+
+button {
+  border: none;
+  border-radius: 0.85rem;
+  padding: 0.65rem 1.2rem;
+  font-weight: 600;
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 25px -20px rgba(37, 99, 235, 0.9);
+  filter: brightness(1.05);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+  box-shadow: none;
+}
+
+button[type='button'] {
+  background: rgba(241, 245, 249, 0.8);
+  color: #0f172a;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+button[type='button']:hover:not(:disabled) {
+  background: rgba(226, 232, 240, 0.95);
+  box-shadow: none;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 0.65rem 0.8rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: #fff;
+  font: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: rgba(37, 99, 235, 0.75);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+label {
+  font-weight: 600;
+  color: #334155;
+}
+
+h1 {
+  margin: 0 0 1.5rem;
+  font-size: clamp(1.75rem, 4vw, 2.25rem);
+  font-weight: 700;
+}
+
+h2 {
+  margin: 0 0 1rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+h3 {
+  margin: 1rem 0 0.75rem;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.page-header h1 {
+  margin: 0;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1.3rem;
+  border-radius: 0.9rem;
+  background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  color: #fff;
+  font-weight: 600;
+  box-shadow: 0 16px 30px -25px rgba(37, 99, 235, 0.9);
+}
+
+.filters {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  padding: 1.75rem;
+  margin-bottom: 1.75rem;
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 1.2rem;
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  box-shadow: 0 35px 60px -45px rgba(15, 23, 42, 0.65);
+}
+
+.filters label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.filter-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: flex-end;
+  grid-column: 1 / -1;
+}
+
+.alert {
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  font-weight: 600;
+  margin: 1rem 0;
+}
+
+.alert.success {
+  background: rgba(22, 163, 74, 0.12);
+  color: #15803d;
+  border: 1px solid rgba(134, 239, 172, 0.75);
+}
+
+.alert.error {
+  background: rgba(239, 68, 68, 0.12);
+  color: #b91c1c;
+  border: 1px solid rgba(252, 165, 165, 0.8);
+}
+
+.loading {
+  text-align: center;
+  color: #64748b;
+  margin: 2rem 0;
+  font-weight: 500;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(255, 255, 255, 0.98);
+  border-radius: 1.1rem;
+  overflow: hidden;
+  box-shadow: 0 32px 60px -45px rgba(15, 23, 42, 0.65);
+}
+
+.data-table th,
+.data-table td {
+  padding: 0.9rem 1.1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.9);
+}
+
+.data-table thead {
+  background: rgba(15, 23, 42, 0.04);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: #475569;
+}
+
+.data-table tbody tr:hover {
+  background: rgba(59, 130, 246, 0.08);
+}
+
+.data-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.empty-state {
+  text-align: center;
+  color: #94a3b8;
+  font-weight: 500;
+  margin: 2.5rem 0;
+}
+
+.pagination {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  padding: 1.5rem;
+  border-radius: 1.2rem;
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 30px 60px -45px rgba(15, 23, 42, 0.55);
+}
+
+.card .form-grid {
+  padding: 0;
+  border: none;
+  box-shadow: none;
+  background: transparent;
+}
+
+.form-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-grid .full-width {
+  grid-column: 1 / -1;
+}
+
+.form-grid .hint {
+  font-weight: 400;
+  color: #64748b;
+  font-size: 0.875rem;
+}
+
+.form-grid .error {
+  color: #dc2626;
+  font-size: 0.85rem;
+}
+
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.98);
+  border-radius: 1.2rem;
+  padding: 1.75rem;
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  box-shadow: 0 35px 70px -50px rgba(15, 23, 42, 0.8);
+  margin-bottom: 2rem;
+}
+
+.card:last-of-type {
+  margin-bottom: 0;
+}
+
+.detail {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  padding: 1.5rem;
+  border-radius: 1.2rem;
+  border: 1px solid rgba(226, 232, 240, 0.9);
+  background: rgba(255, 255, 255, 0.85);
+  margin-bottom: 2rem;
+}
+
+.detail dt {
+  font-weight: 600;
+  color: #475569;
+}
+
+.detail dd {
+  margin: 0;
+  font-weight: 500;
+}
+
+.actions {
+  display: grid;
+  gap: 1.25rem;
+  padding: 1.75rem;
+  border-radius: 1.2rem;
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 30px 60px -45px rgba(15, 23, 42, 0.55);
+}
+
+.action-buttons {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.cancel-form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.stock-summary,
+.sale-summary {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  padding: 1.25rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(226, 232, 240, 0.8);
+  background: rgba(248, 250, 252, 0.9);
+}
+
+.stock-summary dt,
+.sale-summary dt {
+  font-weight: 600;
+  color: #475569;
+}
+
+.stock-summary dd,
+.sale-summary dd {
+  margin: 0;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.item-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.item-row {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(226, 232, 240, 0.7);
+  background: rgba(248, 250, 252, 0.85);
+}
+
+.sale-summary {
+  margin: 1.5rem 0;
+}
+
+@media (max-width: 768px) {
+  .filters,
+  .form-grid,
+  .detail,
+  .actions {
+    grid-template-columns: 1fr;
+  }
+
+  .page-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .pagination {
+    justify-content: center;
+  }
+}


### PR DESCRIPTION
## Summary
- add a sidebar navigation to the admin layout so every feature route is reachable after login
- style the admin shell to match the UX with a sticky top bar and responsive sidebar
- introduce shared global styles for tables, forms and alerts used across the admin views

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5b92edc288329a76772d1c4e94a57