### PR TITLE
Fix admin reservations listing with new API response

### DIFF
--- a/src/app/core/api/reservations.api.ts
+++ b/src/app/core/api/reservations.api.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { environment } from '../../../environments/environment';
 import { PageRequest, PageResponse } from '../models/pagination';
 import {
@@ -25,7 +26,9 @@ export class ReservationsApi {
         }
       });
     }
-    return this.http.get<PageResponse<ReservationViewDTO>>(this.resource, { params: httpParams });
+    return this.http
+      .get<ReservationsListResponse>(this.resource, { params: httpParams })
+      .pipe(map(response => this.normalizeListResponse(response, params)));
   }
 
   create(payload: ReservationCreateDTO): Observable<ReservationViewDTO> {
@@ -55,6 +58,107 @@ export class ReservationsApi {
   pickup(id: string, payload: ReservationPickupRequest = {}): Observable<ReservationViewDTO> {
     return this.http.post<ReservationViewDTO>(`${this.resource}/${encodeURIComponent(id)}/pickup`, payload);
   }
+
+  private normalizeListResponse(
+    response: ReservationsListResponse,
+    params?: PageRequest & { status?: string }
+  ): PageResponse<ReservationViewDTO> {
+    if (Array.isArray(response)) {
+      const totalItems = response.length;
+      const page = resolveMetaNumber(params?.page, 1);
+      const pageSize = resolveMetaPageSize(totalItems, params?.pageSize);
+      return {
+        items: response,
+        totalItems,
+        page,
+        pageSize,
+        totalPages: calculateTotalPages(totalItems, pageSize)
+      };
+    }
+
+    if (isPageResponse<ReservationViewDTO>(response)) {
+      return response;
+    }
+
+    if (isEnvelope(response)) {
+      const meta = response.meta ?? response;
+      const items = response.data;
+      const totalItems = resolveMetaNumber(meta.totalItems, items.length);
+      const page = resolveMetaNumber(meta.page, resolveMetaNumber(params?.page, 1));
+      const pageSize = resolveMetaPageSize(
+        totalItems,
+        resolveMetaNumber(meta.pageSize, params?.pageSize ?? 0)
+      );
+      const totalPages = resolveMetaNumber(
+        meta.totalPages,
+        calculateTotalPages(totalItems, pageSize)
+      );
+
+      return {
+        items,
+        totalItems,
+        page,
+        pageSize,
+        totalPages
+      };
+    }
+
+    const fallbackPage = resolveMetaNumber(params?.page, 1);
+    const fallbackPageSize = resolveMetaNumber(params?.pageSize, 0);
+
+    return {
+      items: [],
+      totalItems: 0,
+      page: fallbackPage,
+      pageSize: fallbackPageSize,
+      totalPages: 0
+    };
+  }
+}
+
+type ReservationsListResponse =
+  | PageResponse<ReservationViewDTO>
+  | ReservationViewDTO[]
+  | ReservationsListEnvelope;
+
+type ReservationsListEnvelope = {
+  data: ReservationViewDTO[];
+  totalItems?: number;
+  page?: number;
+  pageSize?: number;
+  totalPages?: number;
+  meta?: {
+    totalItems?: number;
+    page?: number;
+    pageSize?: number;
+    totalPages?: number;
+  };
+};
+
+function isPageResponse<T>(value: unknown): value is PageResponse<T> {
+  return !!value && typeof value === 'object' && Array.isArray((value as PageResponse<T>).items);
+}
+
+function isEnvelope(value: unknown): value is ReservationsListEnvelope {
+  return !!value && typeof value === 'object' && Array.isArray((value as ReservationsListEnvelope).data);
+}
+
+function resolveMetaNumber(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && !Number.isNaN(value) ? value : fallback;
+}
+
+function resolveMetaPageSize(totalItems: number, requestedPageSize?: number): number {
+  if (requestedPageSize && requestedPageSize > 0) {
+    return requestedPageSize;
+  }
+  return totalItems > 0 ? totalItems : 0;
+}
+
+function calculateTotalPages(totalItems: number, pageSize: number): number {
+  if (!pageSize) {
+    return totalItems > 0 ? 1 : 0;
+  }
+  return Math.max(1, Math.ceil(totalItems / pageSize));
 }
 
 

--- a/src/app/core/models/reservation.ts
+++ b/src/app/core/models/reservation.ts
@@ -2,28 +2,59 @@
  * Reservation base entity.
  * Endpoint: multiple under /api/v1/reservations
  */
+export interface ReservationItemDTO {
+  id: string;
+  productId: string;
+  productTitle?: string;
+  quantity: number;
+  unitPrice?: number;
+  totalPrice?: number;
+}
+
 export interface ReservationDTO {
   id: string;
   code: string;
-  productId: string;
-  customerId: string;
-  quantity: number;
-  status: 'pending' | 'confirmed' | 'cancelled' | 'picked_up';
-  reservedAt: string; // ISO date string
+  status: string;
+  /**
+   * Fecha en la que se creó la reserva.
+   */
+  reservationDate?: string; // ISO date string
+  /**
+   * Equivalente anterior para compatibilidad.
+   */
+  reservedAt?: string; // ISO date string
   desiredPickupDate?: string; // ISO date string
+  pickupDeadline?: string; // ISO date string
   pickedUpAt?: string; // ISO date string
   cancelledAt?: string; // ISO date string
   notes?: string;
+  /**
+   * Información del producto reservada en versiones anteriores.
+   */
+  productId?: string;
+  productName?: string;
+  /**
+   * Información de cliente y totales expuestos por la API actual.
+   */
+  customerId?: string;
+  customerName?: string;
+  customerFirstName?: string;
+  customerLastName?: string;
+  customerEmail?: string;
+  customerPhone?: string;
+  customerDni?: string;
+  quantity?: number;
+  totalAmount?: number;
+  items?: ReservationItemDTO[];
+  createdAt?: string; // ISO date string
+  updatedAt?: string; // ISO date string
 }
 
 /**
  * View returned for management screens.
  * Endpoint: GET /api/v1/reservations, GET /api/v1/reservations/:id
  */
-export interface ReservationViewDTO extends ReservationDTO {
-  productName?: string;
-  customerName?: string;
-}
+export interface ReservationViewDTO extends ReservationDTO {}
 
 /**
  * Create reservation request.


### PR DESCRIPTION
## Summary
- normalize the admin reservations API client to adapt multiple response envelopes
- broaden reservation models and expose helper mappings for product, customer and status information
- refresh admin list and detail views to display the new reservation fields and avoid stale loading states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5c3acb5b0832992fcc502860d7b76