### PR TITLE
feat(admin): implement customers module with v1 api

### DIFF
--- a/src/app/core/api/customers.api.ts
+++ b/src/app/core/api/customers.api.ts
@@ -1,9 +1,13 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { PageRequest, PageResponse } from '../models/pagination';
-import { CustomerCreateDTO, CustomerUpdateDTO, CustomerViewDTO } from '../models/customer';
+import {
+  CustomerCreateDTO,
+  CustomerPatchDTO,
+  CustomerPutDTO,
+  CustomerViewDTO
+} from '../models/customer';
 
 @Injectable({ providedIn: 'root' })
 export class CustomersApi {
@@ -11,27 +15,28 @@ export class CustomersApi {
   private readonly baseUrl = environment.apiBaseUrl;
   private readonly resource = `${this.baseUrl}/api/v1/customers`;
 
-  create(payload: CustomerCreateDTO): Observable<CustomerViewDTO> {
-    return this.http.post<CustomerViewDTO>(this.resource, payload);
-  }
-
-  update(id: string, payload: CustomerUpdateDTO): Observable<CustomerViewDTO> {
-    return this.http.put<CustomerViewDTO>(`${this.resource}/${encodeURIComponent(id)}`, payload);
-  }
-
-  list(params?: PageRequest): Observable<PageResponse<CustomerViewDTO>> {
-    let httpParams = new HttpParams();
-    if (params) {
-      Object.entries(params).forEach(([key, value]) => {
-        if (value !== undefined && value !== null) httpParams = httpParams.set(key, String(value));
-      });
-    }
-    return this.http.get<PageResponse<CustomerViewDTO>>(this.resource, { params: httpParams });
+  list(): Observable<CustomerViewDTO[]> {
+    return this.http.get<CustomerViewDTO[]>(this.resource);
   }
 
   getById(id: string): Observable<CustomerViewDTO> {
     return this.http.get<CustomerViewDTO>(`${this.resource}/${encodeURIComponent(id)}`);
   }
-}
 
+  create(payload: CustomerCreateDTO): Observable<CustomerViewDTO> {
+    return this.http.post<CustomerViewDTO>(this.resource, payload);
+  }
+
+  replace(id: string, payload: CustomerPutDTO): Observable<CustomerViewDTO> {
+    return this.http.put<CustomerViewDTO>(`${this.resource}/${encodeURIComponent(id)}`, payload);
+  }
+
+  updatePartial(id: string, payload: CustomerPatchDTO): Observable<CustomerViewDTO> {
+    return this.http.patch<CustomerViewDTO>(`${this.resource}/${encodeURIComponent(id)}`, payload);
+  }
+
+  delete(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.resource}/${encodeURIComponent(id)}`);
+  }
+}
 

--- a/src/app/core/models/customer.ts
+++ b/src/app/core/models/customer.ts
@@ -6,9 +6,10 @@ export interface CustomerDTO {
   id: string;
   firstName: string;
   lastName: string;
-  email?: string;
-  phone?: string;
+  email: string;
+  phone: string;
   dni: string; // Documento Nacional de Identidad
+  notes: string;
   createdAt: string; // ISO date string
   updatedAt: string; // ISO date string
 }
@@ -20,21 +21,36 @@ export interface CustomerDTO {
 export interface CustomerCreateDTO {
   firstName: string;
   lastName: string;
-  email?: string;
-  phone?: string;
+  email: string;
+  phone: string;
   dni: string;
+  notes: string;
 }
 
 /**
- * Update customer request.
+ * Replace customer request.
  * Endpoint: PUT /api/v1/customers/:id
  */
-export interface CustomerUpdateDTO {
+export interface CustomerPutDTO {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  dni: string;
+  notes: string;
+}
+
+/**
+ * Partial update customer request.
+ * Endpoint: PATCH /api/v1/customers/:id
+ */
+export interface CustomerPatchDTO {
   firstName?: string;
   lastName?: string;
   email?: string;
   phone?: string;
   dni?: string;
+  notes?: string;
 }
 
 /**
@@ -42,5 +58,4 @@ export interface CustomerUpdateDTO {
  * Endpoint: GET /api/v1/customers, GET /api/v1/customers/:id
  */
 export interface CustomerViewDTO extends CustomerDTO {}
-
 

--- a/src/app/features/admin/admin.routes.ts
+++ b/src/app/features/admin/admin.routes.ts
@@ -64,6 +64,14 @@ export const adminRoutes: Routes = [
         loadComponent: () => import('./views/customers-list.component').then(m => m.AdminCustomersListComponent)
       },
       {
+        path: 'customers/new',
+        loadComponent: () => import('./views/customer-detail.component').then(m => m.AdminCustomerDetailComponent)
+      },
+      {
+        path: 'customers/:id/edit',
+        loadComponent: () => import('./views/customer-detail.component').then(m => m.AdminCustomerDetailComponent)
+      },
+      {
         path: 'customers/:id',
         loadComponent: () => import('./views/customer-detail.component').then(m => m.AdminCustomerDetailComponent)
       },

--- a/src/app/features/admin/views/customer-detail.component.ts
+++ b/src/app/features/admin/views/customer-detail.component.ts
@@ -1,83 +1,154 @@
 import { CommonModule } from '@angular/common';
-import { Component, DestroyRef, inject } from '@angular/core';
+import { Component, DestroyRef, computed, inject, signal } from '@angular/core';
 import {
-  AbstractControl,
-  AsyncValidatorFn,
   FormBuilder,
+  FormControl,
   ReactiveFormsModule,
-  ValidationErrors,
   Validators
 } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { catchError, finalize, map, of, switchMap, timer } from 'rxjs';
+import { finalize, timeout } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CustomersApi } from '../../../core/api/customers.api';
-import { CustomerCreateDTO, CustomerUpdateDTO, CustomerViewDTO } from '../../../core/models/customer';
+import {
+  CustomerCreateDTO,
+  CustomerPatchDTO,
+  CustomerPutDTO,
+  CustomerViewDTO
+} from '../../../core/models/customer';
+
+const TIMEOUT_MS = 10000;
 
 @Component({
   selector: 'app-admin-customer-detail',
   standalone: true,
   imports: [CommonModule, ReactiveFormsModule, RouterModule],
   template: `
-    <a routerLink="/admin/customers">&larr; Volver</a>
+    <a routerLink="/admin/customers">&larr; Back to customers</a>
 
-    <h1>{{ isEdit ? 'Editar cliente' : 'Nuevo cliente' }}</h1>
+    <h1 *ngIf="isCreate">New customer</h1>
+    <h1 *ngIf="!isCreate">Customer</h1>
 
-    <section *ngIf="loading" class="loading">Cargando…</section>
-    <section *ngIf="error" class="alert error">{{ error }}</section>
-    <section *ngIf="message" class="alert success">{{ message }}</section>
+    <section *ngIf="loading" class="loading">Loading…</section>
 
-    <form *ngIf="!loading" [formGroup]="form" (ngSubmit)="submit()" class="form-grid">
+    <section *ngIf="error" class="alert error">
+      {{ error }}
+      <button type="button" *ngIf="!isCreate" (click)="reload()">Retry</button>
+    </section>
+
+    <section *ngIf="message()" class="alert success">{{ message() }}</section>
+    <section *ngIf="formError" class="alert error">{{ formError }}</section>
+    <section *ngIf="notesError" class="alert error">{{ notesError }}</section>
+    <section *ngIf="deleteError" class="alert error">{{ deleteError }}</section>
+
+    <form
+      *ngIf="showForm()"
+      [formGroup]="form"
+      (ngSubmit)="submit()"
+      class="form-grid"
+      novalidate
+    >
       <label>
-        Nombres
+        First name
         <input type="text" formControlName="firstName" required />
-        <span class="error" *ngIf="form.controls.firstName.invalid && form.controls.firstName.touched">
-          Campo obligatorio.
-        </span>
+        <span class="error" *ngIf="hasError('firstName', 'required')">Required field.</span>
+        <span class="error" *ngIf="hasError('firstName', 'minlength')">Minimum 2 characters.</span>
       </label>
 
       <label>
-        Apellidos
+        Last name
         <input type="text" formControlName="lastName" required />
-        <span class="error" *ngIf="form.controls.lastName.invalid && form.controls.lastName.touched">
-          Campo obligatorio.
-        </span>
+        <span class="error" *ngIf="hasError('lastName', 'required')">Required field.</span>
+        <span class="error" *ngIf="hasError('lastName', 'minlength')">Minimum 2 characters.</span>
       </label>
 
       <label>
         Email
         <input type="email" formControlName="email" />
-        <span class="error" *ngIf="form.controls.email.invalid && form.controls.email.touched">
-          Ingrese un correo válido.
-        </span>
+        <span class="error" *ngIf="hasError('email', 'email')">Enter a valid email.</span>
       </label>
 
       <label>
-        Teléfono
+        Phone
         <input type="tel" formControlName="phone" />
       </label>
 
       <label>
         DNI
         <input type="text" formControlName="dni" required maxlength="8" />
-        <span class="error" *ngIf="form.controls.dni.hasError('required') && form.controls.dni.touched">
-          Campo obligatorio.
-        </span>
-        <span class="error" *ngIf="form.controls.dni.hasError('pattern') && form.controls.dni.touched">
-          Debe tener 8 dígitos numéricos.
-        </span>
-        <span class="error" *ngIf="form.controls.dni.hasError('dniTaken') && form.controls.dni.touched">
-          Ya existe un cliente con este DNI.
-        </span>
+        <span class="error" *ngIf="hasError('dni', 'required')">Required field.</span>
+        <span class="error" *ngIf="hasError('dni', 'pattern')">Must contain 8 digits.</span>
+      </label>
+
+      <label class="notes-field">
+        Notes
+        <textarea formControlName="notes" rows="4"></textarea>
       </label>
 
       <div class="form-actions">
         <button type="submit" [disabled]="form.invalid || saving">
-          {{ saving ? 'Guardando…' : 'Guardar' }}
+          {{ saving ? 'Saving…' : 'Save' }}
         </button>
-        <button type="button" (click)="resetForm()" [disabled]="saving">Restablecer</button>
+        <button type="button" (click)="cancelEdit()" [disabled]="saving">Cancel</button>
       </div>
     </form>
+
+    <section *ngIf="!isCreate && !showForm() && customer" class="customer-detail">
+      <dl>
+        <div>
+          <dt>Full name</dt>
+          <dd>{{ customer.firstName }} {{ customer.lastName }}</dd>
+        </div>
+        <div>
+          <dt>DNI</dt>
+          <dd>{{ customer.dni }}</dd>
+        </div>
+        <div>
+          <dt>Email</dt>
+          <dd>{{ customer.email || '—' }}</dd>
+        </div>
+        <div>
+          <dt>Phone</dt>
+          <dd>{{ customer.phone || '—' }}</dd>
+        </div>
+        <div>
+          <dt>Notes</dt>
+          <dd>{{ customer.notes || '—' }}</dd>
+        </div>
+        <div>
+          <dt>Created at</dt>
+          <dd>{{ customer.createdAt | date: 'medium' }}</dd>
+        </div>
+        <div>
+          <dt>Updated at</dt>
+          <dd>{{ customer.updatedAt | date: 'medium' }}</dd>
+        </div>
+      </dl>
+
+      <div class="detail-actions">
+        <button type="button" (click)="startEdit()">Edit</button>
+        <button type="button" class="danger" (click)="confirmDelete()" [disabled]="deleting">
+          {{ deleting ? 'Deleting…' : 'Delete' }}
+        </button>
+      </div>
+    </section>
+
+    <section *ngIf="!isCreate && customer && !showForm()" class="notes-editor">
+      <button *ngIf="!notesEditing" type="button" (click)="startNotesEdit()">Add note</button>
+
+      <div *ngIf="notesEditing" class="notes-form">
+        <label>
+          Notes
+          <textarea [formControl]="noteControl" rows="4"></textarea>
+        </label>
+        <div class="form-actions">
+          <button type="button" (click)="saveNotes()" [disabled]="notesSaving">
+            {{ notesSaving ? 'Saving…' : 'Save note' }}
+          </button>
+          <button type="button" (click)="cancelNotesEdit()" [disabled]="notesSaving">Cancel</button>
+        </div>
+      </div>
+    </section>
   `
 })
 export class AdminCustomerDetailComponent {
@@ -88,58 +159,76 @@ export class AdminCustomerDetailComponent {
   private readonly destroyRef = inject(DestroyRef);
 
   readonly form = this.fb.nonNullable.group({
-    firstName: ['', Validators.required],
-    lastName: ['', Validators.required],
+    firstName: ['', [Validators.required, Validators.minLength(2)]],
+    lastName: ['', [Validators.required, Validators.minLength(2)]],
     email: ['', Validators.email],
     phone: [''],
-    dni: [
-      '',
-      [Validators.required, Validators.pattern(/^\d{8}$/)],
-      [this.dniUniqueValidator()]
-    ]
+    dni: ['', [Validators.required, Validators.pattern(/^\d{8}$/)]],
+    notes: ['']
   });
 
-  customerId: string | null = null;
-  isEdit = false;
+  readonly noteControl: FormControl<string> = this.fb.nonNullable.control('');
+
+  customer: CustomerViewDTO | null = null;
   loading = false;
   saving = false;
-  message: string | null = null;
+  deleting = false;
+  notesSaving = false;
+  notesEditing = false;
   error: string | null = null;
+  formError: string | null = null;
+  notesError: string | null = null;
+  deleteError: string | null = null;
+  private readonly messageSignal = signal<string | null>(null);
+
+  readonly message = computed(() => this.messageSignal());
+
+  private readonly customerId = this.route.snapshot.paramMap.get('id');
+  readonly isCreate = !this.customerId || this.customerId === 'new';
+  private readonly isEditRoute = (this.route.snapshot.routeConfig?.path ?? '').endsWith('/edit');
+  private editing = this.isCreate || this.isEditRoute;
 
   constructor() {
-    this.customerId = this.route.snapshot.paramMap.get('id');
-    this.isEdit = !!this.customerId && this.customerId !== 'new';
-    if (this.isEdit && this.customerId) {
+    if (!this.isCreate && this.customerId) {
       this.loadCustomer(this.customerId);
     }
   }
 
-  private loadCustomer(id: string): void {
-    this.loading = true;
-    this.customersApi
-      .getById(id)
-      .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        finalize(() => {
-          this.loading = false;
-        })
-      )
-      .subscribe({
-        next: customer => this.populateForm(customer),
-        error: () => {
-          this.error = 'No se pudo cargar el cliente.';
-        }
-      });
+  showForm(): boolean {
+    return this.editing && !this.loading;
   }
 
-  private populateForm(customer: CustomerViewDTO): void {
+  hasError(controlName: keyof typeof this.form.controls, errorName: string): boolean {
+    const control = this.form.controls[controlName];
+    return control.touched && control.hasError(errorName);
+  }
+
+  startEdit(): void {
+    if (!this.customer) return;
+    this.editing = true;
+    this.notesEditing = false;
+    this.messageSignal.set(null);
     this.form.setValue({
-      firstName: customer.firstName,
-      lastName: customer.lastName,
-      email: customer.email ?? '',
-      phone: customer.phone ?? '',
-      dni: customer.dni
+      firstName: this.customer.firstName,
+      lastName: this.customer.lastName,
+      email: this.customer.email ?? '',
+      phone: this.customer.phone ?? '',
+      dni: this.customer.dni,
+      notes: this.customer.notes ?? ''
     });
+    this.form.markAsPristine();
+  }
+
+  cancelEdit(): void {
+    if (this.isCreate) {
+      this.router.navigate(['/admin/customers']);
+      return;
+    }
+    this.editing = false;
+    this.formError = null;
+    if (this.isEditRoute && this.customerId) {
+      this.router.navigate(['/admin/customers', this.customerId]);
+    }
   }
 
   submit(): void {
@@ -147,24 +236,49 @@ export class AdminCustomerDetailComponent {
       this.form.markAllAsTouched();
       return;
     }
-    this.saving = true;
-    this.message = null;
-    this.error = null;
-    const rawValue = this.form.getRawValue();
+
+    const raw = this.form.getRawValue();
     const payload: CustomerCreateDTO = {
-      firstName: rawValue.firstName.trim(),
-      lastName: rawValue.lastName.trim(),
-      email: rawValue.email?.trim() || undefined,
-      phone: rawValue.phone?.trim() || undefined,
-      dni: rawValue.dni
+      firstName: raw.firstName.trim(),
+      lastName: raw.lastName.trim(),
+      email: this.normalizeEmail(raw.email),
+      phone: this.normalizePhone(raw.phone),
+      dni: raw.dni,
+      notes: this.normalizeNotes(raw.notes)
     };
 
-    const request$ = this.isEdit && this.customerId
-      ? this.customersApi.update(this.customerId, payload as CustomerUpdateDTO)
-      : this.customersApi.create(payload);
+    this.saving = true;
+    this.formError = null;
+    this.messageSignal.set(null);
 
-    request$
+    if (this.isCreate) {
+      this.customersApi
+        .create(payload)
+        .pipe(
+          timeout({ each: TIMEOUT_MS }),
+          takeUntilDestroyed(this.destroyRef),
+          finalize(() => {
+            this.saving = false;
+          })
+        )
+        .subscribe({
+          next: customer => {
+            this.messageSignal.set('Customer created successfully.');
+            this.router.navigate(['/admin/customers', customer.id]);
+          },
+          error: () => {
+            this.formError = 'Unable to create the customer.';
+          }
+        });
+      return;
+    }
+
+    if (!this.customerId) return;
+    const replacePayload: CustomerPutDTO = payload;
+    this.customersApi
+      .replace(this.customerId, replacePayload)
       .pipe(
+        timeout({ each: TIMEOUT_MS }),
         takeUntilDestroyed(this.destroyRef),
         finalize(() => {
           this.saving = false;
@@ -172,47 +286,142 @@ export class AdminCustomerDetailComponent {
       )
       .subscribe({
         next: customer => {
-          this.message = 'Cliente guardado correctamente.';
-          if (!this.isEdit && customer.id) {
+          this.customer = customer;
+          if (this.isEditRoute && this.customerId) {
             this.router.navigate(['/admin/customers', customer.id]);
+          } else {
+            this.editing = false;
           }
+          this.messageSignal.set('Customer updated successfully.');
         },
         error: () => {
-          this.error = 'No se pudo guardar el cliente.';
+          this.formError = 'Unable to update the customer.';
         }
       });
   }
 
-  resetForm(): void {
-    if (this.isEdit && this.customerId) {
+  startNotesEdit(): void {
+    if (!this.customer) return;
+    this.notesEditing = true;
+    this.notesError = null;
+    this.messageSignal.set(null);
+    this.noteControl.setValue(this.customer.notes ?? '');
+  }
+
+  cancelNotesEdit(): void {
+    this.notesEditing = false;
+    this.notesError = null;
+    this.noteControl.setValue(this.customer?.notes ?? '');
+  }
+
+  saveNotes(): void {
+    if (!this.customer || !this.customerId) return;
+    const notes = this.normalizeNotes(this.noteControl.value);
+    const payload: CustomerPatchDTO = { notes };
+    this.notesSaving = true;
+    this.notesError = null;
+    this.messageSignal.set(null);
+
+    this.customersApi
+      .updatePartial(this.customerId, payload)
+      .pipe(
+        timeout({ each: TIMEOUT_MS }),
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.notesSaving = false;
+        })
+      )
+      .subscribe({
+        next: customer => {
+          this.customer = customer;
+          this.noteControl.setValue(customer.notes ?? '');
+          this.notesEditing = false;
+          this.messageSignal.set('Notes updated successfully.');
+        },
+        error: () => {
+          this.notesError = 'Unable to update notes.';
+        }
+      });
+  }
+
+  confirmDelete(): void {
+    if (!this.customerId) return;
+    const confirmed = window.confirm('Delete this customer? This action cannot be undone.');
+    if (!confirmed) return;
+    this.deleteCustomer();
+  }
+
+  private deleteCustomer(): void {
+    if (!this.customerId) return;
+    this.deleting = true;
+    this.deleteError = null;
+    this.customersApi
+      .delete(this.customerId)
+      .pipe(
+        timeout({ each: TIMEOUT_MS }),
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.deleting = false;
+        })
+      )
+      .subscribe({
+        next: () => {
+          this.router.navigate(['/admin/customers']);
+        },
+        error: () => {
+          this.deleteError = 'Unable to delete the customer.';
+        }
+      });
+  }
+
+  reload(): void {
+    if (this.customerId) {
       this.loadCustomer(this.customerId);
-    } else {
-      this.form.reset({ firstName: '', lastName: '', email: '', phone: '', dni: '' });
     }
   }
 
-  private dniUniqueValidator(): AsyncValidatorFn {
-    return (control: AbstractControl): ReturnType<AsyncValidatorFn> => {
-      if (!control.value || control.value.length !== 8) {
-        return of(null);
-      }
-      return timer(300).pipe(
-        switchMap(() =>
-          this.customersApi
-            .list({ page: 1, pageSize: 1, dni: control.value })
-            .pipe(map(response => response.items), catchError(() => of([] as CustomerViewDTO[])))
-        ),
-        map(customers => {
-          if (!customers.length) {
-            return null;
-          }
-          const found = customers[0];
-          if (this.isEdit && this.customerId && found.id === this.customerId) {
-            return null;
-          }
-          return { dniTaken: true } as ValidationErrors;
+  private loadCustomer(id: string): void {
+    this.loading = true;
+    this.error = null;
+    this.customersApi
+      .getById(id)
+      .pipe(
+        timeout({ each: TIMEOUT_MS }),
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.loading = false;
         })
-      );
-    };
+      )
+      .subscribe({
+        next: customer => {
+          this.customer = customer;
+          this.form.setValue({
+            firstName: customer.firstName,
+            lastName: customer.lastName,
+            email: customer.email ?? '',
+            phone: customer.phone ?? '',
+            dni: customer.dni,
+            notes: customer.notes ?? ''
+          });
+          this.editing = this.isEditRoute;
+          this.notesEditing = false;
+        },
+        error: () => {
+          this.error = 'Unable to load the customer.';
+        }
+      });
+  }
+
+  private normalizeEmail(value: string): string {
+    return value ? value.trim().toLowerCase() : '';
+  }
+
+  private normalizePhone(value: string): string {
+    if (!value) return '';
+    return value.replace(/\s+/g, ' ').trim();
+  }
+
+  private normalizeNotes(value: string): string {
+    return value ? value.trim() : '';
   }
 }

--- a/src/app/features/admin/views/customers-list.component.ts
+++ b/src/app/features/admin/views/customers-list.component.ts
@@ -2,11 +2,13 @@ import { CommonModule } from '@angular/common';
 import { Component, DestroyRef, inject } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { finalize } from 'rxjs';
+import { finalize, timeout } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CustomersApi } from '../../../core/api/customers.api';
 import { CustomerViewDTO } from '../../../core/models/customer';
-import { PageResponse } from '../../../core/models/pagination';
+
+const TIMEOUT_MS = 10000;
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
 @Component({
   selector: 'app-admin-customers-list',
@@ -15,51 +17,76 @@ import { PageResponse } from '../../../core/models/pagination';
   template: `
     <section class="page-header">
       <h1>Clientes</h1>
-      <a routerLink="/admin/customers/new" class="btn">Nuevo cliente</a>
+      <a routerLink="/admin/customers/new" class="btn">New customer</a>
     </section>
 
-    <form class="filters" [formGroup]="filterForm" (ngSubmit)="applyFilters()">
+    <form class="filters" [formGroup]="filterForm" (ngSubmit)="applyFilters(true)">
       <label>
-        Buscar
-        <input type="text" formControlName="search" placeholder="Nombre, email o DNI" />
+        Search
+        <input type="text" formControlName="search" placeholder="Name, email or DNI" />
+      </label>
+
+      <label>
+        Last name initial
+        <select formControlName="initial" (change)="applyFilters(true)">
+          <option value="all">All</option>
+          <option *ngFor="let letter of initials" [value]="letter">{{ letter }}</option>
+          <option value="other">#</option>
+        </select>
+      </label>
+
+      <label>
+        Order by updatedAt
+        <select formControlName="sort" (change)="applyFilters(false)">
+          <option value="desc">Newest first</option>
+          <option value="asc">Oldest first</option>
+        </select>
       </label>
 
       <div class="filter-actions">
-        <button type="submit">Aplicar</button>
-        <button type="button" (click)="resetFilters()">Limpiar</button>
+        <button type="submit">Apply</button>
+        <button type="button" (click)="resetFilters()">Clear</button>
       </div>
     </form>
 
-    <section *ngIf="error" class="alert error">{{ error }}</section>
-    <section *ngIf="loading" class="loading">Cargando clientes…</section>
+    <section *ngIf="error" class="alert error">
+      {{ error }}
+      <button type="button" (click)="loadCustomers()">Retry</button>
+    </section>
+    <section *ngIf="loading" class="loading">Loading customers…</section>
 
-    <table *ngIf="!loading && customers.length" class="data-table">
+    <table *ngIf="!loading && !error && customers.length" class="data-table">
       <thead>
         <tr>
-          <th>Nombre</th>
-          <th>Email</th>
-          <th>Teléfono</th>
+          <th>Name</th>
           <th>DNI</th>
+          <th>Email</th>
+          <th>Phone</th>
+          <th>Updated</th>
           <th></th>
         </tr>
       </thead>
       <tbody>
         <tr *ngFor="let customer of customers">
           <td>{{ customer.firstName }} {{ customer.lastName }}</td>
+          <td>{{ customer.dni }}</td>
           <td>{{ customer.email || '—' }}</td>
           <td>{{ customer.phone || '—' }}</td>
-          <td>{{ customer.dni }}</td>
-          <td><a [routerLink]="['/admin/customers', customer.id]">Editar</a></td>
+          <td>{{ customer.updatedAt | date: 'short' }}</td>
+          <td><a [routerLink]="['/admin/customers', customer.id]">View</a></td>
         </tr>
       </tbody>
     </table>
 
-    <p *ngIf="!loading && !customers.length" class="empty-state">No hay clientes para mostrar.</p>
+    <section *ngIf="!loading && !error && !customers.length && totalItems === 0" class="empty-state">
+      <p>No customers yet.</p>
+      <a routerLink="/admin/customers/new" class="btn">New customer</a>
+    </section>
 
     <nav class="pagination" *ngIf="!loading && totalPages > 1">
-      <button type="button" (click)="goToPage(page - 1)" [disabled]="page <= 1">Anterior</button>
-      <span>Página {{ page }} de {{ totalPages }}</span>
-      <button type="button" (click)="goToPage(page + 1)" [disabled]="page >= totalPages">Siguiente</button>
+      <button type="button" (click)="goToPage(page - 1)" [disabled]="page <= 1">Previous</button>
+      <span>Page {{ page }} of {{ totalPages }}</span>
+      <button type="button" (click)="goToPage(page + 1)" [disabled]="page >= totalPages">Next</button>
     </nav>
   `
 })
@@ -69,64 +96,114 @@ export class AdminCustomersListComponent {
   private readonly destroyRef = inject(DestroyRef);
 
   readonly filterForm = this.fb.nonNullable.group({
-    search: ['']
+    search: [''],
+    initial: ['all'],
+    sort: ['desc']
   });
+
+  readonly initials = ALPHABET;
+  readonly pageSize = 10;
+
+  private allCustomers: CustomerViewDTO[] = [];
+  private filteredCustomers: CustomerViewDTO[] = [];
 
   customers: CustomerViewDTO[] = [];
   loading = false;
   error: string | null = null;
   page = 1;
-  pageSize = 10;
-  totalPages = 1;
+  totalPages = 0;
   totalItems = 0;
 
   constructor() {
-    this.loadCustomers(1);
+    this.loadCustomers();
   }
 
-  applyFilters(): void {
-    this.loadCustomers(1);
-  }
-
-  resetFilters(): void {
-    this.filterForm.reset({ search: '' });
-    this.loadCustomers(1);
-  }
-
-  goToPage(page: number): void {
-    if (page < 1 || page > this.totalPages) return;
-    this.loadCustomers(page);
-  }
-
-  private loadCustomers(page: number): void {
+  loadCustomers(): void {
     this.loading = true;
     this.error = null;
-    const { search } = this.filterForm.getRawValue();
     this.customersApi
-      .list({
-        page,
-        pageSize: this.pageSize,
-        search: search || undefined
-      })
+      .list()
       .pipe(
+        timeout({ each: TIMEOUT_MS }),
         takeUntilDestroyed(this.destroyRef),
         finalize(() => {
           this.loading = false;
         })
       )
       .subscribe({
-        next: response => this.handleResponse(response),
+        next: response => {
+          this.allCustomers = response ?? [];
+          this.applyFilters(true);
+        },
         error: () => {
-          this.error = 'No se pudieron cargar los clientes.';
+          this.error = 'Unable to load customers.';
+          this.allCustomers = [];
+          this.applyFilters(true);
         }
       });
   }
 
-  private handleResponse(response: PageResponse<CustomerViewDTO>): void {
-    this.customers = response.items;
-    this.page = response.page;
-    this.pageSize = response.pageSize;
-    this.totalPages = response.totalPages;
-    this.totalItems = response.totalItems;
+  applyFilters(resetPage: boolean): void {
+    const { search, initial, sort } = this.filterForm.getRawValue();
+    const searchValue = search.trim().toLowerCase();
+
+    let filtered = [...this.allCustomers];
+
+    if (searchValue) {
+      filtered = filtered.filter(customer => {
+        const fullName = `${customer.firstName} ${customer.lastName}`.toLowerCase();
+        return (
+          fullName.includes(searchValue) ||
+          (customer.email ?? '').toLowerCase().includes(searchValue) ||
+          customer.dni.toLowerCase().includes(searchValue)
+        );
+      });
+    }
+
+    if (initial !== 'all') {
+      filtered = filtered.filter(customer => {
+        const lastInitial = (customer.lastName ?? '').charAt(0).toUpperCase();
+        if (initial === 'other') {
+          return !ALPHABET.includes(lastInitial);
+        }
+        return lastInitial === initial;
+      });
+    }
+
+    filtered.sort((a, b) => {
+      const aDate = new Date(a.updatedAt).getTime();
+      const bDate = new Date(b.updatedAt).getTime();
+      return sort === 'asc' ? aDate - bDate : bDate - aDate;
+    });
+
+    this.filteredCustomers = filtered;
+    this.totalItems = filtered.length;
+    this.totalPages = this.totalItems ? Math.ceil(this.totalItems / this.pageSize) : 0;
+
+    if (resetPage || this.page > this.totalPages) {
+      this.page = this.totalPages > 0 ? 1 : 0;
+    }
+
+    this.updatePage();
+  }
+
+  resetFilters(): void {
+    this.filterForm.reset({ search: '', initial: 'all', sort: 'desc' });
+    this.applyFilters(true);
+  }
+
+  goToPage(page: number): void {
+    if (page < 1 || page > this.totalPages) return;
+    this.page = page;
+    this.updatePage();
+  }
+
+  private updatePage(): void {
+    if (!this.totalItems || this.page === 0) {
+      this.customers = [];
+      return;
+    }
+    const start = (this.page - 1) * this.pageSize;
+    this.customers = this.filteredCustomers.slice(start, start + this.pageSize);
   }
 }


### PR DESCRIPTION
## Summary
- update customer DTOs and API service to use the /api/v1/customers REST contract including notes, replace, patch and delete calls
- rebuild the admin customers list to fetch the v1 endpoint once and provide search, initial filters, ordering, pagination, and resilient error handling
- redesign the customer detail view to show record metadata, support create/edit forms with validation, partial note updates, delete actions, and add dedicated routes for new and edit flows

## Testing
- npm run test -- --watch=false --browsers=ChromeHeadless *(fails: ChromeHeadless binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d730f8108329be8567cc4a48bacf