### PR TITLE
Update sales API integration to supported endpoints

### DIFF
--- a/src/app/core/api/sales.api.ts
+++ b/src/app/core/api/sales.api.ts
@@ -1,8 +1,8 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { SaleCreateDTO, SaleDTO, SaleViewDTO } from '../models/sale';
+import { SaleCreateDTO, SaleViewDTO } from '../models/sale';
 
 @Injectable({ providedIn: 'root' })
 export class SalesApi {
@@ -18,10 +18,6 @@ export class SalesApi {
     return this.http.get<SaleViewDTO>(`${this.resource}/${encodeURIComponent(id)}`);
   }
 
-  listByDateRange(start: string, end: string): Observable<SaleDTO[]> {
-    const params = new HttpParams().set('start', start).set('end', end);
-    return this.http.get<SaleDTO[]>(this.resource, { params });
-  }
 }
 
 

--- a/src/app/core/models/sale.ts
+++ b/src/app/core/models/sale.ts
@@ -1,41 +1,46 @@
 /**
- * Sale record.
- * Endpoint: GET/POST /api/v1/sales
- */
-export interface SaleDTO {
-  id: string;
-  reservationId?: string;
-  items: Array<{
-    productId: string;
-    quantity: number;
-    unitPrice: number;
-    currency: string;
-  }>;
-  total: number;
-  currency: string;
-  createdAt: string; // ISO date string
-  createdBy: string; // userId
-}
-
-/**
  * Create sale request.
  * Endpoint: POST /api/v1/sales
  */
 export interface SaleCreateDTO {
-  reservationId?: string;
   items: Array<{
     productId: string;
     quantity: number;
     unitPrice: number;
-    currency: string;
   }>;
+  paymentMethod: string;
+  customerId: string;
+  notes?: string;
 }
 
 /**
  * Sale view (detailed).
  * Endpoint: GET /api/v1/sales/:id
  */
-export interface SaleViewDTO extends SaleDTO {}
+export interface SaleViewDTO {
+  id: string;
+  status: string;
+  saleDate: string;
+  totalAmount: number;
+  taxAmount: number;
+  discountAmount: number;
+  notes: string | null;
+  customerId: string;
+  customerFirstName: string;
+  customerLastName: string;
+  cashierId: string;
+  cashierEmail: string;
+  items: Array<{
+    id: string;
+    productId: string;
+    productTitle: string;
+    quantity: number;
+    unitPrice: number;
+    totalPrice: number;
+  }>;
+  createdAt: string;
+  updatedAt: string;
+}
 
 /**
  * Daily sales totals for reporting.

--- a/src/app/features/admin/views/sale-detail.component.ts
+++ b/src/app/features/admin/views/sale-detail.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule, CurrencyPipe, DatePipe } from '@angular/common';
+import { CommonModule, DatePipe } from '@angular/common';
 import { Component, DestroyRef, inject } from '@angular/core';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { finalize } from 'rxjs';
@@ -9,7 +9,7 @@ import { SaleViewDTO } from '../../../core/models/sale';
 @Component({
   selector: 'app-admin-sale-detail',
   standalone: true,
-  imports: [CommonModule, RouterModule, DatePipe, CurrencyPipe],
+  imports: [CommonModule, RouterModule, DatePipe],
   template: `
     <a routerLink="/admin/sales">&larr; Volver</a>
 
@@ -21,19 +21,36 @@ import { SaleViewDTO } from '../../../core/models/sale';
     <article *ngIf="!loading && sale" class="card">
       <header>
         <h2>Venta #{{ sale.id }}</h2>
-        <p>Creada el {{ sale.createdAt | date: 'medium' }} por {{ sale.createdBy }}</p>
+        <p>Estado: {{ sale.status }} · Registrada el {{ sale.saleDate | date: 'medium' }}</p>
       </header>
 
       <dl class="sale-summary">
         <div>
-          <dt>Reserva asociada</dt>
-          <dd>{{ sale.reservationId || 'N/A' }}</dd>
+          <dt>Total</dt>
+          <dd>{{ sale.totalAmount | number: '1.2-2' }}</dd>
         </div>
         <div>
-          <dt>Total</dt>
-          <dd>{{ sale.total | currency: sale.currency }}</dd>
+          <dt>Impuestos</dt>
+          <dd>{{ sale.taxAmount | number: '1.2-2' }}</dd>
+        </div>
+        <div>
+          <dt>Descuento</dt>
+          <dd>{{ sale.discountAmount | number: '1.2-2' }}</dd>
         </div>
       </dl>
+
+      <section class="sale-details">
+        <div>
+          <h3>Cliente</h3>
+          <p>{{ sale.customerFirstName }} {{ sale.customerLastName }}</p>
+          <p>ID: {{ sale.customerId }}</p>
+        </div>
+        <div>
+          <h3>Cajero</h3>
+          <p>{{ sale.cashierEmail }}</p>
+          <p>ID: {{ sale.cashierId }}</p>
+        </div>
+      </section>
 
       <section>
         <h3>Ítems</h3>
@@ -43,15 +60,15 @@ import { SaleViewDTO } from '../../../core/models/sale';
               <th>Producto</th>
               <th>Cantidad</th>
               <th>Precio unitario</th>
-              <th>Subtotal</th>
+              <th>Total</th>
             </tr>
           </thead>
           <tbody>
             <tr *ngFor="let item of sale.items">
-              <td>{{ item.productId }}</td>
+              <td>{{ item.productTitle }}</td>
               <td>{{ item.quantity }}</td>
-              <td>{{ item.unitPrice | currency: item.currency }}</td>
-              <td>{{ (item.unitPrice * item.quantity) | currency: item.currency }}</td>
+              <td>{{ item.unitPrice | number: '1.2-2' }}</td>
+              <td>{{ item.totalPrice | number: '1.2-2' }}</td>
             </tr>
           </tbody>
         </table>

--- a/src/app/features/admin/views/sales-list.component.ts
+++ b/src/app/features/admin/views/sales-list.component.ts
@@ -1,20 +1,19 @@
-import { CommonModule, CurrencyPipe, DatePipe } from '@angular/common';
+import { CommonModule, DatePipe } from '@angular/common';
 import { Component, DestroyRef, inject } from '@angular/core';
 import { FormArray, FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { finalize } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { SalesApi } from '../../../core/api/sales.api';
 import { ProductsApi } from '../../../core/api/products.api';
-import { SaleCreateDTO, SaleDTO } from '../../../core/models/sale';
+import { SaleCreateDTO, SaleViewDTO } from '../../../core/models/sale';
 import { ProductViewDTO } from '../../../core/models/product';
 
 function createSaleItemGroup(fb: FormBuilder) {
   return fb.nonNullable.group({
     productId: ['', Validators.required],
     quantity: [1, [Validators.required, Validators.min(1)]],
-    unitPrice: [0, [Validators.required, Validators.min(0)]],
-    currency: ['PEN', [Validators.required, Validators.minLength(3), Validators.maxLength(3)]]
+    unitPrice: [0, [Validators.required, Validators.min(0)]]
   });
 }
 
@@ -23,7 +22,7 @@ type SaleItemFormGroup = ReturnType<typeof createSaleItemGroup>;
 @Component({
   selector: 'app-admin-sales-list',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterModule, CurrencyPipe, DatePipe],
+  imports: [CommonModule, ReactiveFormsModule, RouterModule, DatePipe],
   template: `
     <section class="page-header">
       <h1>Ventas</h1>
@@ -32,9 +31,14 @@ type SaleItemFormGroup = ReturnType<typeof createSaleItemGroup>;
     <section class="card">
       <h2>Crear venta</h2>
       <form [formGroup]="saleForm" (ngSubmit)="onCreateSale()" class="form-grid">
-        <label class="full-width">
-          ID de reserva (opcional)
-          <input type="text" formControlName="reservationId" placeholder="Reserva relacionada" />
+        <label>
+          Cliente (UUID v4)
+          <input type="text" formControlName="customerId" placeholder="ID del cliente" />
+        </label>
+
+        <label>
+          Método de pago
+          <input type="text" formControlName="paymentMethod" placeholder="Método de pago" />
         </label>
 
         <div formArrayName="items" class="full-width item-list">
@@ -57,11 +61,6 @@ type SaleItemFormGroup = ReturnType<typeof createSaleItemGroup>;
               <input type="number" step="0.01" formControlName="unitPrice" min="0" />
             </label>
 
-            <label>
-              Moneda
-              <input type="text" maxlength="3" formControlName="currency" />
-            </label>
-
             <button type="button" class="link" (click)="removeItem(i)" *ngIf="saleItems.length > 1">Eliminar</button>
           </article>
         </div>
@@ -72,49 +71,49 @@ type SaleItemFormGroup = ReturnType<typeof createSaleItemGroup>;
         </div>
       </form>
 
-      <section *ngIf="createMessage" class="alert success">{{ createMessage }}</section>
       <section *ngIf="createError" class="alert error">{{ createError }}</section>
     </section>
 
     <section class="card">
-      <h2>Buscar ventas</h2>
-      <form [formGroup]="filterForm" (ngSubmit)="onFilterSales()" class="form-grid">
-        <label>
-          Desde
-          <input type="date" formControlName="start" />
+      <h2>Consultar venta</h2>
+      <form [formGroup]="findForm" (ngSubmit)="onFindSale()" class="form-grid">
+        <label class="full-width">
+          ID de la venta
+          <input type="text" formControlName="saleId" placeholder="Ingresa el ID de la venta" />
         </label>
-        <label>
-          Hasta
-          <input type="date" formControlName="end" />
-        </label>
-        <button type="submit" [disabled]="filterForm.invalid || loadingSales">Buscar</button>
+        <button type="submit" [disabled]="findForm.invalid || loadingSale">Buscar</button>
       </form>
 
-      <section *ngIf="listError" class="alert error">{{ listError }}</section>
-      <p *ngIf="loadingSales" class="loading">Cargando ventas…</p>
+      <section *ngIf="findError" class="alert error">{{ findError }}</section>
+      <p *ngIf="loadingSale" class="loading">Buscando venta…</p>
 
-      <table *ngIf="!loadingSales && sales.length" class="data-table">
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>Reserva</th>
-            <th>Total</th>
-            <th>Creada</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr *ngFor="let sale of sales">
-            <td>{{ sale.id }}</td>
-            <td>{{ sale.reservationId || '—' }}</td>
-            <td>{{ sale.total | currency: sale.currency }}</td>
-            <td>{{ sale.createdAt | date: 'short' }}</td>
-            <td><a [routerLink]="['/admin/sales', sale.id]">Ver detalle</a></td>
-          </tr>
-        </tbody>
-      </table>
+      <article *ngIf="!loadingSale && saleResult" class="card sale-preview">
+        <header>
+          <h3>Venta #{{ saleResult.id }}</h3>
+          <p>Registrada el {{ saleResult.saleDate | date: 'medium' }}</p>
+        </header>
 
-      <p *ngIf="!loadingSales && !sales.length" class="empty-state">No se encontraron ventas para el rango indicado.</p>
+        <dl class="sale-summary">
+          <div>
+            <dt>Cliente</dt>
+            <dd>{{ saleResult.customerFirstName }} {{ saleResult.customerLastName }}</dd>
+          </div>
+          <div>
+            <dt>Total</dt>
+            <dd>{{ saleResult.totalAmount | number: '1.2-2' }}</dd>
+          </div>
+          <div>
+            <dt>Estado</dt>
+            <dd>{{ saleResult.status }}</dd>
+          </div>
+        </dl>
+
+        <a [routerLink]="['/admin/sales', saleResult.id]">Ver detalle completo</a>
+      </article>
+
+      <p *ngIf="!loadingSale && !saleResult && !findError" class="empty-state">
+        Ingresa un ID de venta para consultar la información.
+      </p>
     </section>
   `
 })
@@ -123,28 +122,27 @@ export class AdminSalesListComponent {
   private readonly destroyRef = inject(DestroyRef);
   private readonly salesApi = inject(SalesApi);
   private readonly productsApi = inject(ProductsApi);
-
-  readonly filterForm = this.fb.nonNullable.group({
-    start: [this.formatDate(this.daysAgo(7)), Validators.required],
-    end: [this.formatDate(new Date()), Validators.required]
-  });
+  private readonly router = inject(Router);
 
   readonly saleForm = this.fb.nonNullable.group({
-    reservationId: [''],
+    customerId: ['', [Validators.required, Validators.pattern(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/)]],
+    paymentMethod: ['', Validators.required],
     items: this.fb.array<SaleItemFormGroup>([createSaleItemGroup(this.fb)])
   });
 
+  readonly findForm = this.fb.nonNullable.group({
+    saleId: ['', Validators.required]
+  });
+
   products: ProductViewDTO[] = [];
-  sales: SaleDTO[] = [];
-  loadingSales = false;
+  saleResult: SaleViewDTO | null = null;
+  loadingSale = false;
   creatingSale = false;
-  listError: string | null = null;
-  createMessage: string | null = null;
+  findError: string | null = null;
   createError: string | null = null;
 
   constructor() {
     this.loadProducts();
-    this.loadSales();
   }
 
   get saleItems(): FormArray<SaleItemFormGroup> {
@@ -160,12 +158,20 @@ export class AdminSalesListComponent {
     this.saleItems.removeAt(index);
   }
 
-  onFilterSales(): void {
-    if (this.filterForm.invalid) {
-      this.filterForm.markAllAsTouched();
+  onFindSale(): void {
+    if (this.findForm.invalid) {
+      this.findForm.markAllAsTouched();
       return;
     }
-    this.loadSales();
+
+    const saleId = this.findForm.controls.saleId.value.trim();
+    if (!saleId) {
+      this.findError = 'Ingresa un identificador de venta válido.';
+      this.saleResult = null;
+      return;
+    }
+
+    this.loadSaleById(saleId);
   }
 
   onCreateSale(): void {
@@ -190,7 +196,6 @@ export class AdminSalesListComponent {
 
     this.creatingSale = true;
     this.createError = null;
-    this.createMessage = null;
 
     this.salesApi
       .create(payload)
@@ -202,48 +207,15 @@ export class AdminSalesListComponent {
       )
       .subscribe({
         next: sale => {
-          this.createMessage = 'Venta creada correctamente.';
           this.resetSaleForm();
-          this.loadSales();
+          this.router.navigate(['/admin/sales', sale.id]);
         },
-        error: () => {
+        error: error => {
+          if (error.status === 400 && error.error?.message) {
+            this.createError = error.error.message;
+            return;
+          }
           this.createError = 'No se pudo crear la venta.';
-        }
-      });
-  }
-
-  private loadSales(): void {
-    const { start, end } = this.filterForm.getRawValue();
-    if (!start || !end) {
-      this.listError = 'Selecciona el rango de fechas a consultar.';
-      this.sales = [];
-      return;
-    }
-
-    if (new Date(start) > new Date(end)) {
-      this.listError = 'La fecha inicial debe ser anterior o igual a la final.';
-      this.sales = [];
-      return;
-    }
-
-    this.loadingSales = true;
-    this.listError = null;
-
-    this.salesApi
-      .listByDateRange(start, end)
-      .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        finalize(() => {
-          this.loadingSales = false;
-        })
-      )
-      .subscribe({
-        next: sales => {
-          this.sales = sales;
-        },
-        error: () => {
-          this.listError = 'No se pudieron cargar las ventas.';
-          this.sales = [];
         }
       });
   }
@@ -259,41 +231,54 @@ export class AdminSalesListComponent {
   }
 
   private buildSalePayload(): SaleCreateDTO {
-    const { reservationId } = this.saleForm.getRawValue();
     const items = this.saleItems.controls.map(control => {
       const value = control.getRawValue();
       return {
         productId: value.productId,
         quantity: Number(value.quantity),
-        unitPrice: Number(value.unitPrice),
-        currency: value.currency.trim().toUpperCase()
+        unitPrice: Number(value.unitPrice)
       };
     });
 
     return {
-      reservationId: reservationId?.trim() || undefined,
+      customerId: this.saleForm.controls.customerId.value.trim(),
+      paymentMethod: this.saleForm.controls.paymentMethod.value.trim(),
       items: items.filter(item => !!item.productId)
     };
   }
 
   private resetSaleForm(): void {
-    this.saleForm.reset({ reservationId: '' });
+    this.saleForm.reset({ customerId: '', paymentMethod: '' });
     while (this.saleItems.length) {
       this.saleItems.removeAt(0);
     }
     this.saleItems.push(createSaleItemGroup(this.fb));
   }
 
-  private daysAgo(days: number): Date {
-    const today = new Date();
-    today.setDate(today.getDate() - days);
-    return today;
-  }
+  private loadSaleById(id: string): void {
+    this.loadingSale = true;
+    this.findError = null;
+    this.saleResult = null;
 
-  private formatDate(date: Date): string {
-    const year = date.getFullYear();
-    const month = `${date.getMonth() + 1}`.padStart(2, '0');
-    const day = `${date.getDate()}`.padStart(2, '0');
-    return `${year}-${month}-${day}`;
+    this.salesApi
+      .getById(id)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => {
+          this.loadingSale = false;
+        })
+      )
+      .subscribe({
+        next: sale => {
+          this.saleResult = sale;
+        },
+        error: error => {
+          if (error.status === 400 && error.error?.message) {
+            this.findError = error.error.message;
+            return;
+          }
+          this.findError = 'No se pudo encontrar la venta solicitada.';
+        }
+      });
   }
 }


### PR DESCRIPTION
## Summary
- update sales DTOs and API client to match supported POST /api/v1/sales and GET /api/v1/sales/{id} contracts
- adjust admin sales list to send required payload, surface backend errors, and search sales only by identifier
- refresh sale detail view to display the new response fields

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5dd56d4d083299efdb3f8a2c187e7