### PR TITLE
Ajusta creación de reservas para clientes existentes

### DIFF
--- a/src/app/core/models/reservation.ts
+++ b/src/app/core/models/reservation.ts
@@ -14,7 +14,7 @@ export interface Reservation {
   code: string;
   status: ReservationStatus;
   reservationDate: string;
-  pickupDeadline: string;
+  pickupDeadline?: string;
   totalAmount: number;
   notes?: string;
   customerId: string;
@@ -40,7 +40,7 @@ export interface ReservationCreateRequest {
   customerId?: string;
   customerData?: ReservationCustomerData;
   items: ReservationCreateItem[];
-  pickupDeadline: string;
+  pickupDeadline?: string;
   notes?: string;
 }
 

--- a/src/app/features/admin/views/reservation-detail.component.ts
+++ b/src/app/features/admin/views/reservation-detail.component.ts
@@ -198,10 +198,6 @@ import { ToastService } from '../../../shared/services/toast.service';
           <dd>{{ reservation.reservationDate | date: 'medium' }}</dd>
         </div>
         <div>
-          <dt>Fecha límite de retiro</dt>
-          <dd>{{ reservation.pickupDeadline | date: 'medium' }}</dd>
-        </div>
-        <div>
           <dt>Total</dt>
           <dd>{{ reservation.totalAmount | currency: 'USD' }}</dd>
         </div>

--- a/src/app/features/admin/views/reservations-list.component.ts
+++ b/src/app/features/admin/views/reservations-list.component.ts
@@ -221,7 +221,6 @@ import { ToastService } from '../../../shared/services/toast.service';
           <th>Cliente</th>
           <th>Estado</th>
           <th>Fecha de reserva</th>
-          <th>Fecha límite</th>
           <th>Total</th>
           <th></th>
         </tr>
@@ -232,7 +231,6 @@ import { ToastService } from '../../../shared/services/toast.service';
           <td>{{ getCustomerLabel(reservation) }}</td>
           <td><span class="status-badge {{ reservation.status }}">{{ getStatusLabel(reservation.status) }}</span></td>
           <td>{{ reservation.reservationDate | date: 'short' }}</td>
-          <td>{{ reservation.pickupDeadline | date: 'short' }}</td>
           <td>{{ reservation.totalAmount | currency: 'USD' }}</td>
           <td class="table-actions">
             <a [routerLink]="['/admin/reservations', reservation.id]">Ver</a>


### PR DESCRIPTION
## Summary
- simplificar el formulario de reservas internas para usar únicamente clientes existentes
- asegurar que el payload de creación incluya los datos completos del cliente y un pickupDeadline automático
- extender el contrato de creación de reservas para contemplar el campo pickupDeadline esperado por el backend

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5e86b83708329ab0663f78cc4f7a5