### PR TITLE
Add pickup deadline to reservation creation payload

### DIFF
--- a/src/app/core/models/reservation.ts
+++ b/src/app/core/models/reservation.ts
@@ -40,6 +40,7 @@ export interface ReservationCreateRequest {
   customerId?: string;
   customerData?: ReservationCustomerData;
   items: ReservationCreateItem[];
+  pickupDeadline?: string;
   notes?: string;
 }
 

--- a/src/app/features/admin/views/reservation-create.component.ts
+++ b/src/app/features/admin/views/reservation-create.component.ts
@@ -446,6 +446,7 @@ export class AdminReservationCreateComponent {
           phone
         },
         items,
+        pickupDeadline: this.buildPickupDeadline(),
         notes: trimmedNotes ? trimmedNotes : undefined
       };
     }
@@ -471,6 +472,7 @@ export class AdminReservationCreateComponent {
         phone
       },
       items,
+      pickupDeadline: this.buildPickupDeadline(),
       notes: trimmedNotes ? trimmedNotes : undefined
     };
   }


### PR DESCRIPTION
## Summary
- add the pickupDeadline field to the reservation creation model
- include the generated pickup deadline when building the reservation create request

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5f05fc0a08329aead4c7f8359710e