### PR TITLE
Fix product category selection

### DIFF
--- a/src/app/core/api/categories.api.ts
+++ b/src/app/core/api/categories.api.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { PageRequest, PageResponse } from '../models/pagination';
 import { CategoryCreateDTO, CategoryUpdateDTO, CategoryViewDTO } from '../models/category';
@@ -19,14 +19,40 @@ export class CategoriesApi {
     return this.http.put<CategoryViewDTO>(`${this.resource}/${encodeURIComponent(id)}`, payload);
   }
 
-  list(params?: PageRequest & { isActive?: boolean }): Observable<PageResponse<CategoryViewDTO>> {
+  list(params?: PageRequest & { active?: boolean }): Observable<PageResponse<CategoryViewDTO>> {
     let httpParams = new HttpParams();
     if (params) {
       Object.entries(params).forEach(([key, value]) => {
-        if (value !== undefined && value !== null) httpParams = httpParams.set(key, String(value));
+        if (value === undefined || value === null) return;
+        if (typeof value === 'boolean') {
+          httpParams = httpParams.set(key, value ? 'true' : 'false');
+          return;
+        }
+        httpParams = httpParams.set(key, String(value));
       });
     }
-    return this.http.get<PageResponse<CategoryViewDTO>>(this.resource, { params: httpParams });
+    return this.http
+      .get<PageResponse<CategoryViewDTO> | CategoryViewDTO[]>(this.resource, { params: httpParams })
+      .pipe(
+        map(response => {
+          if (Array.isArray(response)) {
+            const fallbackPageSize = params?.pageSize ?? (response.length || 1);
+            const fallbackPage = params?.page ?? 1;
+            const totalPages = fallbackPageSize
+              ? Math.max(1, Math.ceil((response.length || 0) / fallbackPageSize))
+              : 1;
+
+            return {
+              items: response,
+              totalItems: response.length,
+              page: fallbackPage,
+              pageSize: fallbackPageSize,
+              totalPages
+            } as PageResponse<CategoryViewDTO>;
+          }
+          return response;
+        })
+      );
   }
 
   getById(id: string): Observable<CategoryViewDTO> {

--- a/src/app/core/models/category.ts
+++ b/src/app/core/models/category.ts
@@ -5,9 +5,9 @@
 export interface CategoryDTO {
   id: string;
   name: string;
-  slug: string;
+  slug?: string;
   description?: string;
-  isActive: boolean;
+  active: boolean;
   createdAt: string; // ISO date string
   updatedAt: string; // ISO date string
 }
@@ -20,7 +20,7 @@ export interface CategoryCreateDTO {
   name: string;
   slug?: string;
   description?: string;
-  isActive?: boolean;
+  active?: boolean;
 }
 
 /**
@@ -31,7 +31,7 @@ export interface CategoryUpdateDTO {
   name?: string;
   slug?: string;
   description?: string;
-  isActive?: boolean;
+  active?: boolean;
 }
 
 /**

--- a/src/app/features/admin/views/product-detail.component.ts
+++ b/src/app/features/admin/views/product-detail.component.ts
@@ -200,10 +200,11 @@ export class AdminProductDetailComponent {
 
   private loadCategories(): void {
     this.categoriesApi
-      .list({ page: 1, pageSize: 100, sort: 'name,asc' })
+      .list({ page: 1, pageSize: 100, sort: 'name,asc', active: true })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: response => (this.categories = response.items)
+        next: response =>
+          (this.categories = (response.items ?? []).filter(category => category.active))
       });
   }
 


### PR DESCRIPTION
## Summary
- align category DTOs with the backend `active` flag
- allow filtering categories by `active` in the API client
- show only active categories in the product form dropdown
- normalize category list responses that return bare arrays so the dropdown data loads consistently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5f24dcdc08329ab0b583ff21674a0