### PR TITLE
feat(admin): enhance dashboard overview

### DIFF
--- a/src/app/features/admin/views/dashboard.component.css
+++ b/src/app/features/admin/views/dashboard.component.css
@@ -1,0 +1,204 @@
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.page-header__subtitle {
+  margin: 0.25rem 0 0;
+  color: #5f6368;
+}
+
+.btn {
+  padding: 0.6rem 1.2rem;
+  border-radius: 0.5rem;
+  border: 1px solid #1a73e8;
+  background: #1a73e8;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.btn[disabled] {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.btn--ghost {
+  background: transparent;
+  color: #1a73e8;
+}
+
+.btn--ghost:not([disabled]):hover {
+  background: rgba(26, 115, 232, 0.1);
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.metric-card {
+  padding: 1.25rem;
+  background: #fff;
+  border-radius: 0.75rem;
+  border: 1px solid #e3e7eb;
+  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.08);
+}
+
+.metric-card h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  color: #5f6368;
+  text-transform: uppercase;
+}
+
+.metric-card strong {
+  display: block;
+  font-size: 1.8rem;
+  margin-bottom: 0.25rem;
+  color: #1f1f1f;
+}
+
+.metric-card p {
+  margin: 0;
+  color: #6f7781;
+}
+
+.metric-card--highlight {
+  background: linear-gradient(135deg, #1a73e8, #4a90e2);
+  color: #fff;
+  border-color: transparent;
+}
+
+.metric-card--highlight h2,
+.metric-card--highlight p {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.metric-card--highlight strong {
+  color: #fff;
+}
+
+.alert {
+  padding: 1rem;
+  border-radius: 0.75rem;
+  margin-bottom: 2rem;
+}
+
+.alert--error {
+  background: #fdecea;
+  color: #b71c1c;
+  border: 1px solid #f5c6cb;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.panel {
+  background: #fff;
+  border-radius: 0.75rem;
+  border: 1px solid #e3e7eb;
+  box-shadow: 0 1px 2px rgba(16, 24, 40, 0.08);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.panel__header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.panel__counter {
+  font-size: 0.9rem;
+  color: #5f6368;
+}
+
+.panel__empty {
+  margin: 0;
+  color: #5f6368;
+}
+
+.reservation-list,
+.sales-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.reservation-list li,
+.sales-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.reservation-list__meta {
+  display: flex;
+  flex-direction: column;
+  text-align: right;
+  gap: 0.25rem;
+}
+
+.sales-list__date {
+  flex: 1;
+  color: #5f6368;
+}
+
+.sales-list__amount {
+  font-weight: 600;
+}
+
+.sales-list__orders {
+  color: #5f6368;
+}
+
+.dashboard-footer {
+  margin-top: 2rem;
+  font-size: 0.9rem;
+  color: #5f6368;
+}
+
+@media (max-width: 640px) {
+  .page-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .reservation-list li,
+  .sales-list li {
+    flex-direction: column;
+    align-items: flex-start;
+    text-align: left;
+  }
+
+  .reservation-list__meta {
+    text-align: left;
+  }
+}

--- a/src/app/features/admin/views/dashboard.component.html
+++ b/src/app/features/admin/views/dashboard.component.html
@@ -1,0 +1,91 @@
+<section class="page-header">
+  <div>
+    <h1>Dashboard administrativo</h1>
+    <p class="page-header__subtitle">
+      Resumen rápido de la operación para hoy {{ today | dateFormat: 'es-PE': { dateStyle: 'long' } }}.
+    </p>
+  </div>
+  <button type="button" (click)="reload()" [disabled]="loading()" class="btn btn--ghost">
+    {{ loading() ? 'Actualizando…' : 'Actualizar' }}
+  </button>
+</section>
+
+<section class="metrics" aria-label="Indicadores principales">
+  <article class="metric-card">
+    <h2>Reservas pendientes</h2>
+    <strong>{{ metrics().pendingReservations }}</strong>
+    <p>Esperando confirmación del equipo.</p>
+  </article>
+  <article class="metric-card">
+    <h2>Reservas de hoy</h2>
+    <strong>{{ metrics().todaysReservations }}</strong>
+    <p>Solicitadas para la fecha actual.</p>
+  </article>
+  <article class="metric-card">
+    <h2>Clientes registrados</h2>
+    <strong>{{ metrics().customers }}</strong>
+    <p>Cuenta total en el sistema.</p>
+  </article>
+  <article class="metric-card">
+    <h2>Productos activos</h2>
+    <strong>{{ metrics().activeProducts }}</strong>
+    <p>Disponibles para reservar o vender.</p>
+  </article>
+  <article class="metric-card metric-card--highlight">
+    <h2>Ventas del día</h2>
+    <strong>{{ metrics().todaysSalesAmount | currencyFormat: metrics().currency }}</strong>
+    <p>{{ metrics().todaysSalesOrders }} pedidos registrados.</p>
+  </article>
+</section>
+
+<section *ngIf="error()" class="alert alert--error">{{ error() }}</section>
+
+<section class="dashboard-grid">
+  <article class="panel">
+    <header class="panel__header">
+      <h2>Reservas pendientes recientes</h2>
+      <span *ngIf="pendingReservations().length" class="panel__counter">
+        {{ pendingReservations().length }} pendientes
+      </span>
+    </header>
+
+    <p *ngIf="!pendingReservations().length && !loading()" class="panel__empty">
+      ¡Todo al día! No tienes reservas pendientes por revisar.
+    </p>
+
+    <ul *ngIf="pendingReservations().length" class="reservation-list">
+      <li *ngFor="let reservation of pendingReservations()">
+        <div>
+          <strong>{{ reservation.code }}</strong>
+          <span>{{ reservation.reservationDate | dateFormat: 'es-PE': { dateStyle: 'medium', timeStyle: 'short' } }}</span>
+        </div>
+        <div class="reservation-list__meta">
+          <span>{{ reservation.customerFirstName }} {{ reservation.customerLastName }}</span>
+          <strong>{{ reservation.totalAmount | currencyFormat: 'PEN' }}</strong>
+        </div>
+      </li>
+    </ul>
+  </article>
+
+  <article class="panel">
+    <header class="panel__header">
+      <h2>Ventas de los últimos 7 días</h2>
+    </header>
+
+    <p *ngIf="!salesTrend().length && !loading()" class="panel__empty">
+      Aún no hay registros de ventas para la semana.
+    </p>
+
+    <ol *ngIf="salesTrend().length" class="sales-list">
+      <li *ngFor="let sale of salesTrend()">
+        <span class="sales-list__date">{{ sale.date | dateFormat: 'es-PE' }}</span>
+        <span class="sales-list__amount">{{ sale.totalSales | currencyFormat: sale.currency }}</span>
+        <span class="sales-list__orders">{{ sale.totalOrders }} pedidos</span>
+      </li>
+    </ol>
+  </article>
+</section>
+
+<footer class="dashboard-footer" *ngIf="lastUpdated()">
+  Última actualización: {{ lastUpdated() | dateFormat: 'es-PE': { dateStyle: 'medium', timeStyle: 'short' } }}
+</footer>

--- a/src/app/features/admin/views/dashboard.component.ts
+++ b/src/app/features/admin/views/dashboard.component.ts
@@ -1,12 +1,165 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { forkJoin } from 'rxjs';
+import { finalize } from 'rxjs/operators';
+import { CustomersApi } from '../../../core/api/customers.api';
+import { ProductsApi } from '../../../core/api/products.api';
+import { ReportsApi } from '../../../core/api/reports.api';
+import { ReservationsApi } from '../../../core/api/reservations.api';
+import { Reservation } from '../../../core/models/reservation';
+import { DailySalesTotalsDTO } from '../../../core/models/sale';
+import { CurrencyFormatPipe, DateFormatPipe, ToastService } from '../../../shared';
+
+interface DashboardMetrics {
+  pendingReservations: number;
+  todaysReservations: number;
+  customers: number;
+  activeProducts: number;
+  todaysSalesAmount: number;
+  todaysSalesOrders: number;
+  currency: string;
+}
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  template: `
-    <h1>Dashboard admin</h1>
-  `
+  imports: [CommonModule, CurrencyFormatPipe, DateFormatPipe],
+  styleUrls: ['./dashboard.component.css'],
+  templateUrl: './dashboard.component.html'
 })
-export class DashboardComponent {}
+export class DashboardComponent implements OnInit {
+  private readonly reservationsApi = inject(ReservationsApi);
+  private readonly customersApi = inject(CustomersApi);
+  private readonly productsApi = inject(ProductsApi);
+  private readonly reportsApi = inject(ReportsApi);
+  private readonly toastService = inject(ToastService);
 
+  protected today = new Date();
 
+  protected readonly loading = signal(false);
+  protected readonly error = signal<string | null>(null);
+  protected readonly lastUpdated = signal<Date | null>(null);
+  protected readonly metrics = signal<DashboardMetrics>({
+    pendingReservations: 0,
+    todaysReservations: 0,
+    customers: 0,
+    activeProducts: 0,
+    todaysSalesAmount: 0,
+    todaysSalesOrders: 0,
+    currency: 'PEN'
+  });
+  protected readonly pendingReservations = signal<Reservation[]>([]);
+  protected readonly salesTrend = signal<DailySalesTotalsDTO[]>([]);
+
+  ngOnInit(): void {
+    this.reload();
+  }
+
+  reload(): void {
+    if (this.loading()) {
+      return;
+    }
+
+    this.today = new Date();
+    const { startOfWeekIso, endOfDayIso, todayKey } = this.buildDateRanges();
+
+    this.loading.set(true);
+    this.error.set(null);
+
+    forkJoin({
+      reservations: this.reservationsApi.list(), // GET /api/v1/reservations
+      customers: this.customersApi.list(), // GET /api/v1/customers
+      products: this.productsApi.list({ page: 1, pageSize: 1, active: true }), // GET /api/v1/products
+      sales: this.reportsApi.daily(startOfWeekIso, endOfDayIso) // GET /api/v1/reports/sales/daily
+    })
+      .pipe(finalize(() => this.loading.set(false)))
+      .subscribe({
+        next: ({ reservations, customers, products, sales }) => {
+          this.updateReservationsData(reservations);
+          const customersCount = Array.isArray(customers) ? customers.length : 0;
+          const activeProductsTotal =
+            typeof products.totalItems === 'number' ? products.totalItems : products.items?.length ?? 0;
+          this.updateMetrics({
+            reservations,
+            customersCount,
+            activeProducts: activeProductsTotal,
+            sales,
+            todayKey
+          });
+          this.salesTrend.set(this.normalizeSalesTrend(sales));
+          this.lastUpdated.set(new Date());
+        },
+        error: () => {
+          this.error.set('No se pudo actualizar el dashboard. Intenta nuevamente.');
+          this.toastService.error('Ocurrió un problema al cargar el resumen.');
+        }
+      });
+  }
+
+  private updateReservationsData(reservations: Reservation[]): void {
+    const pending = [...reservations]
+      .filter((reservation) => reservation.status === 'PENDING')
+      .sort((a, b) => new Date(b.reservationDate).getTime() - new Date(a.reservationDate).getTime())
+      .slice(0, 5);
+
+    this.pendingReservations.set(pending);
+  }
+
+  private updateMetrics(params: {
+    reservations: Reservation[];
+    customersCount: number;
+    activeProducts: number;
+    sales: DailySalesTotalsDTO[];
+    todayKey: string;
+  }): void {
+    const { reservations, customersCount, activeProducts, sales, todayKey } = params;
+
+    const todaysReservations = reservations.filter((reservation) =>
+      this.normalizeDate(reservation.reservationDate) === todayKey
+    );
+    const pendingReservations = reservations.filter((reservation) => reservation.status === 'PENDING');
+
+    const todaysSales = sales.find((sale) => sale.date === todayKey);
+
+    this.metrics.set({
+      pendingReservations: pendingReservations.length,
+      todaysReservations: todaysReservations.length,
+      customers: customersCount,
+      activeProducts,
+      todaysSalesAmount: todaysSales?.totalSales ?? 0,
+      todaysSalesOrders: todaysSales?.totalOrders ?? 0,
+      currency: todaysSales?.currency ?? 'PEN'
+    });
+  }
+
+  private normalizeSalesTrend(sales: DailySalesTotalsDTO[]): DailySalesTotalsDTO[] {
+    return [...sales]
+      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+      .slice(0, 7);
+  }
+
+  private buildDateRanges(): { startOfWeekIso: string; endOfDayIso: string; todayKey: string } {
+    const now = this.today;
+    const start = new Date(now);
+    start.setDate(now.getDate() - 6);
+    start.setHours(0, 0, 0, 0);
+
+    const end = new Date(now);
+    end.setHours(23, 59, 59, 999);
+
+    return {
+      startOfWeekIso: this.toIsoDateTime(start),
+      endOfDayIso: this.toIsoDateTime(end),
+      todayKey: this.normalizeDate(now)
+    };
+  }
+
+  private toIsoDateTime(date: Date): string {
+    return date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+  }
+
+  private normalizeDate(value: string | Date): string {
+    const date = value instanceof Date ? value : new Date(value);
+    return date.toISOString().slice(0, 10);
+  }
+}


### PR DESCRIPTION
## Summary
- replace the empty admin dashboard with a metrics view that summarizes reservations, customers, products and sales
- add sections for recent pending reservations and weekly sales trends using existing REST endpoints
- style the dashboard with reusable cards and panels so the overview no longer looks empty

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5f564f5c08329b45fa9c2e8fa77c8