### PR TITLE
Add public home page and align reservation flow

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -15,5 +15,5 @@ export const appRoutes: Routes = [
     canActivate: [authGuard],
     loadChildren: () => import('./features/admin/admin.routes').then(m => m.adminRoutes)
   },
-  { path: '**', redirectTo: 'catalog', pathMatch: 'full' }
+  { path: '**', redirectTo: '', pathMatch: 'full' }
 ];

--- a/src/app/core/api/public-categories.api.ts
+++ b/src/app/core/api/public-categories.api.ts
@@ -9,7 +9,7 @@ import { PublicCategoryView } from '../models/public';
 export class PublicCategoriesApi {
   private readonly http = inject(HttpClient);
   private readonly baseUrl = environment.apiBaseUrl;
-  private readonly resource = `${this.baseUrl}/api/v1/public/categories`;
+  private readonly resource = `${this.baseUrl}/public/categories`;
 
   list(params?: PageRequest): Observable<PageResponse<PublicCategoryView>> {
     let httpParams = new HttpParams();

--- a/src/app/core/api/public-products.api.ts
+++ b/src/app/core/api/public-products.api.ts
@@ -9,7 +9,7 @@ import { PublicProductView } from '../models/public';
 export class PublicProductsApi {
   private readonly http = inject(HttpClient);
   private readonly baseUrl = environment.apiBaseUrl;
-  private readonly resource = `${this.baseUrl}/api/v1/public/products`;
+  private readonly resource = `${this.baseUrl}/public/products`;
 
   list(params?: PageRequest & { categoryId?: string }): Observable<PageResponse<PublicProductView>> {
     let httpParams = new HttpParams();

--- a/src/app/core/api/public-reservations.api.ts
+++ b/src/app/core/api/public-reservations.api.ts
@@ -8,7 +8,7 @@ import { PublicReservationCreateRequest, PublicReservationCreatedResponse } from
 export class PublicReservationsApi {
   private readonly http = inject(HttpClient);
   private readonly baseUrl = environment.apiBaseUrl;
-  private readonly resource = `${this.baseUrl}/api/v1/public/reservations`;
+  private readonly resource = `${this.baseUrl}/public/reservations`;
 
   create(request: PublicReservationCreateRequest): Observable<PublicReservationCreatedResponse> {
     return this.http.post<PublicReservationCreatedResponse>(this.resource, request);

--- a/src/app/core/models/public.ts
+++ b/src/app/core/models/public.ts
@@ -1,6 +1,6 @@
 /**
  * Public product data visible in the storefront.
- * Endpoint: GET /api/v1/public/products, GET /api/v1/public/products/:id
+ * Endpoint: GET /public/products, GET /public/products/:id
  */
 export interface PublicProductView {
   id: string;
@@ -17,7 +17,7 @@ export interface PublicProductView {
 
 /**
  * Public category data visible in the storefront.
- * Endpoint: GET /api/v1/public/categories, GET /api/v1/public/categories/:id
+ * Endpoint: GET /public/categories, GET /public/categories/:id
  */
 export interface PublicCategoryView {
   id: string;
@@ -28,23 +28,38 @@ export interface PublicCategoryView {
 }
 
 /**
- * Payload to create a reservation from the public site.
- * Endpoint: POST /api/v1/public/reservations
+ * Detailed contact data required when creating a reservation from the public site.
  */
-export interface PublicReservationCreateRequest {
+export interface PublicReservationCustomerData {
+  firstName: string;
+  lastName: string;
+  dni: string;
+  email: string;
+  phone: string;
+}
+
+/**
+ * Information about a product reserved from the public site.
+ */
+export interface PublicReservationItem {
   productId: string;
   quantity: number;
-  desiredPickupDate?: string; // ISO date string
-  customerDocument?: string; // e.g. DNI
-  customerName: string;
-  customerEmail?: string;
-  customerPhone?: string;
+}
+
+/**
+ * Payload to create a reservation from the public site.
+ * Endpoint: POST /public/reservations
+ */
+export interface PublicReservationCreateRequest {
+  customerData: PublicReservationCustomerData;
+  items: PublicReservationItem[];
+  pickupDeadline: string; // ISO date string
   notes?: string;
 }
 
 /**
  * Response returned after creating a reservation on the public site.
- * Endpoint: POST /api/v1/public/reservations
+ * Endpoint: POST /public/reservations
  */
 export interface PublicReservationCreatedResponse {
   reservationId: string;

--- a/src/app/features/public/public.routes.ts
+++ b/src/app/features/public/public.routes.ts
@@ -6,7 +6,10 @@ export const publicRoutes: Routes = [
     path: '',
     component: PublicLayoutComponent,
     children: [
-      { path: '', redirectTo: 'catalog', pathMatch: 'full' },
+      {
+        path: '',
+        loadComponent: () => import('./views/home.component').then(m => m.PublicHomeComponent)
+      },
       {
         path: 'catalog',
         loadComponent: () => import('./views/catalog-list.component').then(m => m.CatalogListComponent)

--- a/src/app/features/public/publicLayout.component.ts
+++ b/src/app/features/public/publicLayout.component.ts
@@ -8,7 +8,9 @@ import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
   template: `
     <header class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm">
       <div class="container">
-        <a class="navbar-brand fw-semibold" routerLink="/">Lumen Librería</a>
+        <a class="navbar-brand fw-semibold text-uppercase" routerLink="/">
+          LIBRERIA LUMEN
+        </a>
         <button
           class="navbar-toggler"
           type="button"
@@ -21,7 +23,16 @@ import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
           <span class="navbar-toggler-icon"></span>
         </button>
         <nav class="collapse navbar-collapse" id="publicNavbar">
-          <ul class="navbar-nav ms-auto gap-lg-3">
+          <ul class="navbar-nav ms-auto align-items-lg-center gap-lg-3">
+            <li class="nav-item">
+              <a
+                class="nav-link"
+                routerLink="/"
+                routerLinkActive="active"
+                [routerLinkActiveOptions]="{ exact: true }"
+                >Inicio</a
+              >
+            </li>
             <li class="nav-item">
               <a
                 class="nav-link"
@@ -38,7 +49,7 @@ import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
               <a class="nav-link" routerLink="/reserve" routerLinkActive="active">Reservar</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" routerLink="/login">Ingresar</a>
+              <a class="btn btn-outline-light px-3" routerLink="/login">Iniciar sesión</a>
             </li>
           </ul>
         </nav>

--- a/src/app/features/public/views/home.component.ts
+++ b/src/app/features/public/views/home.component.ts
@@ -1,0 +1,159 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+type HttpMethod = 'GET' | 'POST';
+
+interface PublicEndpoint {
+  method: HttpMethod;
+  path: string;
+  title: string;
+  description: string;
+}
+
+@Component({
+  selector: 'app-public-home',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  template: `
+    <section class="d-flex flex-column gap-5">
+      <div class="bg-white border rounded-4 shadow-sm overflow-hidden">
+        <div class="row g-0 align-items-center">
+          <div class="col-12 col-lg-7 p-5 d-flex flex-column gap-3">
+            <span class="badge text-bg-primary text-uppercase align-self-start">Bienvenido</span>
+            <h1 class="display-5 fw-semibold mb-0">LIBRERIA LUMEN</h1>
+            <p class="text-muted fs-5 mb-0">
+              Explora el catálogo público de productos, conoce las categorías disponibles y realiza
+              reservas sin necesidad de iniciar sesión. Gestiona todo desde una interfaz clara y
+              accesible.
+            </p>
+            <div class="d-flex flex-column flex-sm-row gap-3">
+              <a class="btn btn-primary btn-lg px-4" routerLink="/catalog">Ver catálogo</a>
+              <a class="btn btn-outline-primary btn-lg px-4" routerLink="/reserve">Reservar ahora</a>
+              <a class="btn btn-outline-dark btn-lg px-4" routerLink="/login">Iniciar sesión</a>
+            </div>
+          </div>
+          <div class="col-12 col-lg-5 bg-primary-subtle p-5">
+            <div class="d-flex flex-column gap-4 text-primary-emphasis">
+              <div>
+                <h2 class="h4 fw-semibold">Acceso público inmediato</h2>
+                <p class="mb-0">
+                  Las rutas públicas te permiten consultar información actualizada sin crear una cuenta.
+                  Si necesitas administrar inventario o ventas, inicia sesión desde aquí cuando estés
+                  listo.
+                </p>
+              </div>
+              <div>
+                <h2 class="h4 fw-semibold">Reservas confiables</h2>
+                <p class="mb-0">
+                  Verifica siempre el cuerpo JSON antes de enviarlo para evitar rechazos y asegurar que el
+                  pedido llegue al equipo correcto.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <section class="d-flex flex-column gap-4">
+        <header class="d-flex flex-column flex-lg-row align-items-lg-center gap-3">
+          <div>
+            <h2 class="h4 mb-1">Rutas públicas disponibles</h2>
+            <p class="text-muted mb-0">Consulta y consume los endpoints sin autenticación previa.</p>
+          </div>
+          <a class="btn btn-link ms-lg-auto" routerLink="/reserve">Ir a reservas</a>
+        </header>
+
+        <div class="row g-4">
+          <div class="col-12 col-md-6 col-xxl-4" *ngFor="let endpoint of endpoints">
+            <article class="card h-100 shadow-sm border-0">
+              <div class="card-body d-flex flex-column gap-3">
+                <div class="d-flex align-items-center gap-3">
+                  <span
+                    class="badge text-uppercase"
+                    [ngClass]="endpoint.method === 'GET' ? 'text-bg-success' : 'text-bg-warning'"
+                  >
+                    {{ endpoint.method }}
+                  </span>
+                  <code class="text-primary-emphasis fw-semibold">{{ endpoint.path }}</code>
+                </div>
+                <div>
+                  <h3 class="h5 mb-1">{{ endpoint.title }}</h3>
+                  <p class="text-muted mb-0">{{ endpoint.description }}</p>
+                </div>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="bg-dark text-white rounded-4 shadow-sm p-4 p-lg-5 d-flex flex-column gap-4">
+        <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center">
+          <div class="flex-grow-1">
+            <h2 class="h4 mb-2">Ejemplo de reserva correcta</h2>
+            <p class="text-white-50 mb-0">
+              Antes de confirmar, valida que tu cuerpo JSON respete la estructura solicitada. Puedes
+              copiar este formato como referencia.
+            </p>
+          </div>
+          <a class="btn btn-outline-light px-4" routerLink="/reserve">Generar mi reserva</a>
+        </div>
+        <pre class="bg-black text-white rounded-4 p-4 mb-0 overflow-auto">
+          <code [innerText]="reservationExample"></code>
+        </pre>
+      </section>
+    </section>
+  `
+})
+export class PublicHomeComponent {
+  readonly endpoints: PublicEndpoint[] = [
+    {
+      method: 'GET',
+      path: '/public/products',
+      title: 'Catálogo público',
+      description: 'Obtén el listado completo de productos disponibles con información de stock.'
+    },
+    {
+      method: 'GET',
+      path: '/public/products/{id}',
+      title: 'Detalle de producto',
+      description: 'Consulta la información detallada de un producto específico usando su identificador.'
+    },
+    {
+      method: 'GET',
+      path: '/public/categories',
+      title: 'Listado de categorías',
+      description: 'Explora las categorías para organizar y filtrar los productos del catálogo.'
+    },
+    {
+      method: 'GET',
+      path: '/public/categories/{id}',
+      title: 'Detalle de categoría',
+      description: 'Recupera la descripción y los productos asociados a una categoría concreta.'
+    },
+    {
+      method: 'POST',
+      path: '/public/reservations',
+      title: 'Crear reserva',
+      description: 'Envía los datos completos del cliente y los productos para apartar unidades disponibles.'
+    }
+  ];
+
+  readonly reservationExample = `{
+  "customerData": {
+    "firstName": "string",
+    "lastName": "string",
+    "dni": "37999589",
+    "email": "user@example.com",
+    "phone": "(71())05+9(544 89"
+  },
+  "items": [
+    {
+      "productId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "quantity": 1
+    }
+  ],
+  "pickupDeadline": "2025-09-26T02:26:14.200Z",
+  "notes": "string"
+}`;
+}

--- a/src/app/features/public/views/reserve.component.ts
+++ b/src/app/features/public/views/reserve.component.ts
@@ -1,12 +1,12 @@
 import { CommonModule } from '@angular/common';
-import { Component, inject, signal } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { AbstractControl, FormBuilder, ReactiveFormsModule, ValidatorFn, Validators } from '@angular/forms';
 import { finalize } from 'rxjs';
 import { PublicProductsApi, PublicReservationsApi } from '../../../core/api';
 import {
   PublicProductView,
-  PublicReservationCreatedResponse,
-  PublicReservationCreateRequest
+  PublicReservationCreateRequest,
+  PublicReservationCreatedResponse
 } from '../../../core/models';
 
 @Component({
@@ -16,20 +16,56 @@ import {
   template: `
     <section class="d-flex flex-column gap-4">
       <header class="bg-white shadow-sm rounded-4 p-4 border">
-        <h1 class="h3 mb-2">Reserva con DNI</h1>
+        <h1 class="h3 mb-2">Reserva con LIBRERIA LUMEN</h1>
         <p class="text-muted mb-0">
-          Completa tus datos y selecciona un producto para apartarlo. Todos los campos son obligatorios
-          salvo las observaciones.
+          Completa tus datos y selecciona un producto para apartarlo. Antes de enviar, revisa el cuerpo
+          JSON para asegurarte de que coincide exactamente con el formato requerido por la API pública.
         </p>
       </header>
 
       <div class="row g-4">
-        <div class="col-12 col-lg-8">
+        <div class="col-12 col-xl-8">
           <form class="card shadow-sm border-0" [formGroup]="form" (ngSubmit)="submit()" novalidate>
-            <div class="card-body">
+            <div class="card-body p-4">
               <fieldset class="border-0 p-0" [disabled]="loading()">
-                <div class="row g-3">
+                <div class="row g-4">
+                  <div class="col-12">
+                    <h2 class="h5 text-primary mb-0">Datos de contacto</h2>
+                  </div>
+
                   <div class="col-md-6">
+                    <label for="firstName" class="form-label">Nombre</label>
+                    <input
+                      id="firstName"
+                      type="text"
+                      class="form-control"
+                      formControlName="firstName"
+                      required
+                      autocomplete="given-name"
+                      [class.is-invalid]="hasError('firstName', 'required')"
+                    />
+                    <div class="invalid-feedback" *ngIf="hasError('firstName', 'required')">
+                      El nombre es obligatorio.
+                    </div>
+                  </div>
+
+                  <div class="col-md-6">
+                    <label for="lastName" class="form-label">Apellido</label>
+                    <input
+                      id="lastName"
+                      type="text"
+                      class="form-control"
+                      formControlName="lastName"
+                      required
+                      autocomplete="family-name"
+                      [class.is-invalid]="hasError('lastName', 'required')"
+                    />
+                    <div class="invalid-feedback" *ngIf="hasError('lastName', 'required')">
+                      El apellido es obligatorio.
+                    </div>
+                  </div>
+
+                  <div class="col-md-4">
                     <label for="dni" class="form-label">DNI</label>
                     <input
                       id="dni"
@@ -50,52 +86,47 @@ import {
                     </div>
                   </div>
 
-                  <div class="col-md-6">
-                    <label for="name" class="form-label">Nombre completo</label>
-                    <input
-                      id="name"
-                      type="text"
-                      class="form-control"
-                      formControlName="customerName"
-                      required
-                      [class.is-invalid]="hasError('customerName', 'required')"
-                    />
-                    <div class="invalid-feedback" *ngIf="hasError('customerName', 'required')">
-                      El nombre es obligatorio.
-                    </div>
-                  </div>
-
-                  <div class="col-md-6">
+                  <div class="col-md-4">
                     <label for="email" class="form-label">Correo electrónico</label>
                     <input
                       id="email"
                       type="email"
                       class="form-control"
-                      formControlName="customerEmail"
+                      formControlName="email"
                       required
-                      [class.is-invalid]="hasError('customerEmail', 'required') || hasError('customerEmail', 'email')"
+                      autocomplete="email"
+                      [class.is-invalid]="hasError('email', 'required') || hasError('email', 'email')"
                     />
-                    <div class="invalid-feedback" *ngIf="hasError('customerEmail', 'required')">
+                    <div class="invalid-feedback" *ngIf="hasError('email', 'required')">
                       El correo es obligatorio.
                     </div>
-                    <div class="invalid-feedback" *ngIf="hasError('customerEmail', 'email')">
+                    <div class="invalid-feedback" *ngIf="hasError('email', 'email')">
                       Ingresa un correo válido.
                     </div>
                   </div>
 
-                  <div class="col-md-6">
+                  <div class="col-md-4">
                     <label for="phone" class="form-label">Teléfono</label>
                     <input
                       id="phone"
                       type="tel"
                       class="form-control"
-                      formControlName="customerPhone"
+                      formControlName="phone"
                       required
-                      [class.is-invalid]="hasError('customerPhone', 'required')"
+                      autocomplete="tel"
+                      [class.is-invalid]="hasError('phone', 'required')"
                     />
-                    <div class="invalid-feedback" *ngIf="hasError('customerPhone', 'required')">
+                    <div class="invalid-feedback" *ngIf="hasError('phone', 'required')">
                       El teléfono es obligatorio.
                     </div>
+                  </div>
+                </div>
+
+                <hr class="text-secondary-subtle my-4" />
+
+                <div class="row g-4">
+                  <div class="col-12">
+                    <h2 class="h5 text-primary mb-0">Detalle de la reserva</h2>
                   </div>
 
                   <div class="col-md-6">
@@ -120,7 +151,7 @@ import {
                     </div>
                   </div>
 
-                  <div class="col-md-6">
+                  <div class="col-md-3">
                     <label for="quantity" class="form-label">Cantidad</label>
                     <input
                       id="quantity"
@@ -139,18 +170,24 @@ import {
                     </div>
                   </div>
 
-                  <div class="col-md-6">
-                    <label for="pickup" class="form-label">Fecha límite de retiro</label>
+                  <div class="col-md-3">
+                    <label for="pickupDeadline" class="form-label">Fecha y hora límite</label>
                     <input
-                      id="pickup"
-                      type="date"
+                      id="pickupDeadline"
+                      type="datetime-local"
                       class="form-control"
-                      formControlName="desiredPickupDate"
-                      [min]="today"
-                      [class.is-invalid]="hasError('desiredPickupDate', 'minDate')"
+                      formControlName="pickupDeadline"
+                      required
+                      [min]="pickupDeadlineMinValue"
+                      [class.is-invalid]="
+                        hasError('pickupDeadline', 'required') || hasError('pickupDeadline', 'futureDateTime')
+                      "
                     />
-                    <div class="invalid-feedback" *ngIf="hasError('desiredPickupDate', 'minDate')">
-                      Selecciona una fecha desde hoy en adelante.
+                    <div class="invalid-feedback" *ngIf="hasError('pickupDeadline', 'required')">
+                      La fecha límite es obligatoria.
+                    </div>
+                    <div class="invalid-feedback" *ngIf="hasError('pickupDeadline', 'futureDateTime')">
+                      Selecciona una fecha y hora a partir del momento actual.
                     </div>
                   </div>
 
@@ -165,13 +202,13 @@ import {
                     ></textarea>
                   </div>
                 </div>
-
-                <div class="d-flex justify-content-end mt-4">
-                  <button type="submit" class="btn btn-primary" [disabled]="form.invalid || loading()">
-                    <ng-container *ngIf="!loading(); else loadingTpl">Reservar</ng-container>
-                  </button>
-                </div>
               </fieldset>
+
+              <div class="d-flex justify-content-end mt-4">
+                <button type="submit" class="btn btn-primary" [disabled]="form.invalid || loading()">
+                  <ng-container *ngIf="!loading(); else loadingTpl">Generar reserva</ng-container>
+                </button>
+              </div>
             </div>
           </form>
 
@@ -188,28 +225,41 @@ import {
           </div>
         </div>
 
-        <div class="col-12 col-lg-4">
-          <div class="card shadow-sm border-0 h-100">
-            <div class="card-body d-flex flex-column gap-3">
-              <h2 class="h5 mb-0">Resumen de tu reserva</h2>
-              <p class="text-muted mb-0">
-                Recibirás un correo con el código y la fecha límite una vez confirmada la reserva.
-              </p>
+        <div class="col-12 col-xl-4">
+          <div class="d-flex flex-column gap-3">
+            <div class="card shadow-sm border-0 h-100">
+              <div class="card-body d-flex flex-column gap-3">
+                <h2 class="h5 mb-0">Confirmación de reserva</h2>
+                <p class="text-muted mb-0">
+                  Recibirás un correo con el código y la fecha límite una vez confirmada la reserva.
+                </p>
 
-              <div *ngIf="confirmation() as result; else pending">
-                <div class="alert alert-success" role="status">
-                  <h3 class="h6 fw-semibold">Reserva generada</h3>
-                  <p class="mb-1"><strong>Código:</strong> {{ result.code }}</p>
-                  <p class="mb-1"><strong>ID interno:</strong> {{ result.reservationId }}</p>
-                  <p class="mb-0" *ngIf="result.expiresAt">
-                    <strong>Vence:</strong> {{ result.expiresAt | date: 'longDate' }}
-                  </p>
+                <div *ngIf="confirmation() as result; else pending">
+                  <div class="alert alert-success mb-0" role="status">
+                    <h3 class="h6 fw-semibold">Reserva generada</h3>
+                    <p class="mb-1"><strong>Código:</strong> {{ result.code }}</p>
+                    <p class="mb-1"><strong>ID interno:</strong> {{ result.reservationId }}</p>
+                    <p class="mb-0" *ngIf="result.expiresAt">
+                      <strong>Vence:</strong> {{ result.expiresAt | date: 'longDate' }}
+                    </p>
+                  </div>
                 </div>
-              </div>
 
-              <ng-template #pending>
-                <p class="text-muted">Completa el formulario para generar el código de retiro.</p>
-              </ng-template>
+                <ng-template #pending>
+                  <p class="text-muted mb-0">Completa el formulario para generar el código de retiro.</p>
+                </ng-template>
+              </div>
+            </div>
+
+            <div class="card shadow-sm border-0">
+              <div class="card-body d-flex flex-column gap-3">
+                <h2 class="h6 text-uppercase text-muted mb-0">JSON a enviar</h2>
+                <p class="text-muted mb-0">
+                  Verifica cada campo antes de enviar. Este es el cuerpo exacto que se enviará a
+                  <code>POST /public/reservations</code>.
+                </p>
+                <pre class="bg-dark text-white rounded-3 p-3 mb-0 small"><code>{{ requestPreview() }}</code></pre>
+              </div>
             </div>
           </div>
         </div>
@@ -229,16 +279,15 @@ export class ReserveComponent {
   private readonly publicReservationsApi = inject(PublicReservationsApi);
   private readonly publicProductsApi = inject(PublicProductsApi);
 
-  readonly today = new Date().toISOString().split('T')[0];
-
   readonly form = this.fb.nonNullable.group({
+    firstName: ['', Validators.required],
+    lastName: ['', Validators.required],
     dni: ['', [Validators.required, Validators.pattern(/^\d{8}$/)]],
-    customerName: ['', Validators.required],
-    customerEmail: ['', [Validators.required, Validators.email]],
-    customerPhone: ['', Validators.required],
+    email: ['', [Validators.required, Validators.email]],
+    phone: ['', Validators.required],
     productId: ['', Validators.required],
     quantity: [1, [Validators.required, Validators.min(1)]],
-    desiredPickupDate: ['', this.minDateValidator()],
+    pickupDeadline: ['', [Validators.required, this.futureDateTimeValidator()]],
     notes: ['']
   });
 
@@ -246,6 +295,31 @@ export class ReserveComponent {
   readonly error = signal('');
   readonly products = signal<PublicProductView[]>([]);
   readonly confirmation = signal<PublicReservationCreatedResponse | null>(null);
+
+  readonly requestPreview = computed(() => {
+    const raw = this.form.getRawValue();
+    const payload = {
+      customerData: {
+        firstName: raw.firstName || '',
+        lastName: raw.lastName || '',
+        dni: raw.dni || '',
+        email: raw.email || '',
+        phone: raw.phone || ''
+      },
+      items: [
+        {
+          productId: raw.productId || '',
+          quantity: raw.quantity ?? 1
+        }
+      ],
+      pickupDeadline: raw.pickupDeadline ? this.toIsoString(raw.pickupDeadline) : '',
+      ...(raw.notes ? { notes: raw.notes } : {})
+    } satisfies PublicReservationCreateRequest & { notes?: string };
+
+    return JSON.stringify(payload, null, 2);
+  });
+
+  readonly pickupDeadlineMinValue = this.toInputLocalValue(new Date());
 
   constructor() {
     this.fetchProducts();
@@ -263,15 +337,23 @@ export class ReserveComponent {
     }
 
     const raw = this.form.getRawValue();
+
     const request: PublicReservationCreateRequest = {
-      productId: raw.productId,
-      quantity: raw.quantity,
-      desiredPickupDate: raw.desiredPickupDate ? new Date(raw.desiredPickupDate).toISOString() : undefined,
-      customerDocument: raw.dni,
-      customerName: raw.customerName,
-      customerEmail: raw.customerEmail,
-      customerPhone: raw.customerPhone,
-      notes: raw.notes || undefined
+      customerData: {
+        firstName: raw.firstName,
+        lastName: raw.lastName,
+        dni: raw.dni,
+        email: raw.email,
+        phone: raw.phone
+      },
+      items: [
+        {
+          productId: raw.productId,
+          quantity: raw.quantity
+        }
+      ],
+      pickupDeadline: this.toIsoString(raw.pickupDeadline),
+      ...(raw.notes ? { notes: raw.notes } : {})
     };
 
     this.loading.set(true);
@@ -285,13 +367,14 @@ export class ReserveComponent {
         next: (response) => {
           this.confirmation.set(response);
           this.form.reset({
+            firstName: '',
+            lastName: '',
             dni: '',
-            customerName: '',
-            customerEmail: '',
-            customerPhone: '',
+            email: '',
+            phone: '',
             productId: '',
             quantity: 1,
-            desiredPickupDate: '',
+            pickupDeadline: '',
             notes: ''
           });
         },
@@ -322,21 +405,32 @@ export class ReserveComponent {
       });
   }
 
-  private minDateValidator(): ValidatorFn {
+  private futureDateTimeValidator(): ValidatorFn {
     return (control: AbstractControl): Record<string, boolean> | null => {
       if (!control.value) {
         return null;
       }
 
       const selected = new Date(control.value);
-      const today = new Date(this.today);
+      if (Number.isNaN(selected.getTime())) {
+        return { futureDateTime: true };
+      }
 
-      if (selected < today) {
-        return { minDate: true };
+      const now = new Date();
+      if (selected < now) {
+        return { futureDateTime: true };
       }
 
       return null;
     };
   }
 
+  private toIsoString(value: string): string {
+    return new Date(value).toISOString();
+  }
+
+  private toInputLocalValue(date: Date): string {
+    const localDate = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+    return localDate.toISOString().slice(0, 16);
+  }
 }


### PR DESCRIPTION
## Summary
- add a new public home page that highlights LIBRERIA LUMEN, exposes public API routes, and links to login and reservations
- refresh the public navigation layout so visitors stay on the public site until they choose to log in
- update public API clients and the reservation form to use the /public endpoints and the required reservation JSON structure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5f9cf9ca88329ad480190ba4f6829