### PR TITLE
Add timeouts to public catalog API requests

### DIFF
--- a/src/app/core/api/public-categories.api.ts
+++ b/src/app/core/api/public-categories.api.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, timeout } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { PageRequest, PageResponse } from '../models/pagination';
 import { PublicCategoryView } from '../models/public';
@@ -10,6 +10,7 @@ export class PublicCategoriesApi {
   private readonly http = inject(HttpClient);
   private readonly baseUrl = environment.apiBaseUrl;
   private readonly resource = `${this.baseUrl}/public/categories`;
+  private readonly requestTimeoutMs = 10000;
 
   list(params?: PageRequest): Observable<PageResponse<PublicCategoryView>> {
     let httpParams = new HttpParams();
@@ -20,11 +21,15 @@ export class PublicCategoriesApi {
         }
       });
     }
-    return this.http.get<PageResponse<PublicCategoryView>>(this.resource, { params: httpParams });
+    return this.http
+      .get<PageResponse<PublicCategoryView>>(this.resource, { params: httpParams })
+      .pipe(timeout(this.requestTimeoutMs));
   }
 
   getById(id: string): Observable<PublicCategoryView> {
-    return this.http.get<PublicCategoryView>(`${this.resource}/${encodeURIComponent(id)}`);
+    return this.http
+      .get<PublicCategoryView>(`${this.resource}/${encodeURIComponent(id)}`)
+      .pipe(timeout(this.requestTimeoutMs));
   }
 }
 

--- a/src/app/core/api/public-products.api.ts
+++ b/src/app/core/api/public-products.api.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, timeout } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { PageRequest, PageResponse } from '../models/pagination';
 import { PublicProductView } from '../models/public';
@@ -10,6 +10,7 @@ export class PublicProductsApi {
   private readonly http = inject(HttpClient);
   private readonly baseUrl = environment.apiBaseUrl;
   private readonly resource = `${this.baseUrl}/public/products`;
+  private readonly requestTimeoutMs = 10000;
 
   list(params?: PageRequest & { categoryId?: string }): Observable<PageResponse<PublicProductView>> {
     let httpParams = new HttpParams();
@@ -20,11 +21,15 @@ export class PublicProductsApi {
         }
       });
     }
-    return this.http.get<PageResponse<PublicProductView>>(this.resource, { params: httpParams });
+    return this.http
+      .get<PageResponse<PublicProductView>>(this.resource, { params: httpParams })
+      .pipe(timeout(this.requestTimeoutMs));
   }
 
   getById(id: string): Observable<PublicProductView> {
-    return this.http.get<PublicProductView>(`${this.resource}/${encodeURIComponent(id)}`);
+    return this.http
+      .get<PublicProductView>(`${this.resource}/${encodeURIComponent(id)}`)
+      .pipe(timeout(this.requestTimeoutMs));
   }
 }
 


### PR DESCRIPTION
## Summary
- add client-side timeouts to the public products and categories API wrappers to prevent endless pending calls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5fc2e536483298d50bbf1fe82d9cd