### PR TITLE
Fix public reservation payload structure

### DIFF
--- a/src/app/core/api/public-categories.api.ts
+++ b/src/app/core/api/public-categories.api.ts
@@ -1,8 +1,7 @@
 import { Injectable, inject } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
+import { Observable, timeout } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { PageRequest, PageResponse } from '../models/pagination';
 import { PublicCategoryView } from '../models/public';
 
 @Injectable({ providedIn: 'root' })
@@ -10,21 +9,16 @@ export class PublicCategoriesApi {
   private readonly http = inject(HttpClient);
   private readonly baseUrl = environment.apiBaseUrl;
   private readonly resource = `${this.baseUrl}/public/categories`;
+  private readonly requestTimeoutMs = 10000;
 
-  list(params?: PageRequest): Observable<PageResponse<PublicCategoryView>> {
-    let httpParams = new HttpParams();
-    if (params) {
-      Object.entries(params).forEach(([key, value]) => {
-        if (value !== undefined && value !== null) {
-          httpParams = httpParams.set(key, String(value));
-        }
-      });
-    }
-    return this.http.get<PageResponse<PublicCategoryView>>(this.resource, { params: httpParams });
+  list(): Observable<PublicCategoryView[]> {
+    return this.http.get<PublicCategoryView[]>(this.resource).pipe(timeout(this.requestTimeoutMs));
   }
 
   getById(id: string): Observable<PublicCategoryView> {
-    return this.http.get<PublicCategoryView>(`${this.resource}/${encodeURIComponent(id)}`);
+    return this.http
+      .get<PublicCategoryView>(`${this.resource}/${encodeURIComponent(id)}`)
+      .pipe(timeout(this.requestTimeoutMs));
   }
 }
 

--- a/src/app/core/api/public-products.api.ts
+++ b/src/app/core/api/public-products.api.ts
@@ -1,8 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, timeout } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { PageRequest, PageResponse } from '../models/pagination';
 import { PublicProductView } from '../models/public';
 
 @Injectable({ providedIn: 'root' })
@@ -10,8 +9,9 @@ export class PublicProductsApi {
   private readonly http = inject(HttpClient);
   private readonly baseUrl = environment.apiBaseUrl;
   private readonly resource = `${this.baseUrl}/public/products`;
+  private readonly requestTimeoutMs = 10000;
 
-  list(params?: PageRequest & { categoryId?: string }): Observable<PageResponse<PublicProductView>> {
+  list(params?: { search?: string; categoryId?: string }): Observable<PublicProductView[]> {
     let httpParams = new HttpParams();
     if (params) {
       Object.entries(params).forEach(([key, value]) => {
@@ -20,11 +20,15 @@ export class PublicProductsApi {
         }
       });
     }
-    return this.http.get<PageResponse<PublicProductView>>(this.resource, { params: httpParams });
+    return this.http
+      .get<PublicProductView[]>(this.resource, { params: httpParams })
+      .pipe(timeout(this.requestTimeoutMs));
   }
 
   getById(id: string): Observable<PublicProductView> {
-    return this.http.get<PublicProductView>(`${this.resource}/${encodeURIComponent(id)}`);
+    return this.http
+      .get<PublicProductView>(`${this.resource}/${encodeURIComponent(id)}`)
+      .pipe(timeout(this.requestTimeoutMs));
   }
 }
 

--- a/src/app/core/models/public.ts
+++ b/src/app/core/models/public.ts
@@ -4,15 +4,16 @@
  */
 export interface PublicProductView {
   id: string;
-  name: string;
+  title?: string;
+  name?: string;
   author?: string;
   description?: string;
   price: number;
-  currency: string;
+  currency?: string;
   categoryId: string;
   categoryName?: string;
   imageUrl?: string;
-  availableStock?: number;
+  stock?: number;
 }
 
 /**
@@ -22,20 +23,9 @@ export interface PublicProductView {
 export interface PublicCategoryView {
   id: string;
   name: string;
-  slug: string;
+  slug?: string;
   description?: string;
   productCount?: number;
-}
-
-/**
- * Detailed contact data required when creating a reservation from the public site.
- */
-export interface PublicReservationCustomerData {
-  firstName: string;
-  lastName: string;
-  dni: string;
-  email: string;
-  phone: string;
 }
 
 /**
@@ -50,6 +40,14 @@ export interface PublicReservationItem {
  * Payload to create a reservation from the public site.
  * Endpoint: POST /public/reservations
  */
+export interface PublicReservationCustomerData {
+  firstName: string;
+  lastName: string;
+  dni: string;
+  email: string;
+  phone: string;
+}
+
 export interface PublicReservationCreateRequest {
   customerData: PublicReservationCustomerData;
   items: PublicReservationItem[];

--- a/src/app/features/public/public.routes.ts
+++ b/src/app/features/public/public.routes.ts
@@ -19,10 +19,6 @@ export const publicRoutes: Routes = [
         loadComponent: () => import('./views/product-detail.component').then(m => m.ProductDetailComponent)
       },
       {
-        path: 'categories',
-        loadComponent: () => import('./views/categories-list.component').then(m => m.CategoriesListComponent)
-      },
-      {
         path: 'reserve',
         loadComponent: () => import('./views/reserve.component').then(m => m.ReserveComponent)
       }

--- a/src/app/features/public/publicLayout.component.ts
+++ b/src/app/features/public/publicLayout.component.ts
@@ -43,9 +43,6 @@ import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
               >
             </li>
             <li class="nav-item">
-              <a class="nav-link" routerLink="/categories" routerLinkActive="active">Categorías</a>
-            </li>
-            <li class="nav-item">
               <a class="nav-link" routerLink="/reserve" routerLinkActive="active">Reservar</a>
             </li>
             <li class="nav-item">

--- a/src/app/features/public/views/home.component.ts
+++ b/src/app/features/public/views/home.component.ts
@@ -2,158 +2,19 @@ import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
-type HttpMethod = 'GET' | 'POST';
-
-interface PublicEndpoint {
-  method: HttpMethod;
-  path: string;
-  title: string;
-  description: string;
-}
-
 @Component({
   selector: 'app-public-home',
   standalone: true,
   imports: [CommonModule, RouterModule],
   template: `
-    <section class="d-flex flex-column gap-5">
-      <div class="bg-white border rounded-4 shadow-sm overflow-hidden">
-        <div class="row g-0 align-items-center">
-          <div class="col-12 col-lg-7 p-5 d-flex flex-column gap-3">
-            <span class="badge text-bg-primary text-uppercase align-self-start">Bienvenido</span>
-            <h1 class="display-5 fw-semibold mb-0">LIBRERIA LUMEN</h1>
-            <p class="text-muted fs-5 mb-0">
-              Explora el catálogo público de productos, conoce las categorías disponibles y realiza
-              reservas sin necesidad de iniciar sesión. Gestiona todo desde una interfaz clara y
-              accesible.
-            </p>
-            <div class="d-flex flex-column flex-sm-row gap-3">
-              <a class="btn btn-primary btn-lg px-4" routerLink="/catalog">Ver catálogo</a>
-              <a class="btn btn-outline-primary btn-lg px-4" routerLink="/reserve">Reservar ahora</a>
-              <a class="btn btn-outline-dark btn-lg px-4" routerLink="/login">Iniciar sesión</a>
-            </div>
-          </div>
-          <div class="col-12 col-lg-5 bg-primary-subtle p-5">
-            <div class="d-flex flex-column gap-4 text-primary-emphasis">
-              <div>
-                <h2 class="h4 fw-semibold">Acceso público inmediato</h2>
-                <p class="mb-0">
-                  Las rutas públicas te permiten consultar información actualizada sin crear una cuenta.
-                  Si necesitas administrar inventario o ventas, inicia sesión desde aquí cuando estés
-                  listo.
-                </p>
-              </div>
-              <div>
-                <h2 class="h4 fw-semibold">Reservas confiables</h2>
-                <p class="mb-0">
-                  Verifica siempre el cuerpo JSON antes de enviarlo para evitar rechazos y asegurar que el
-                  pedido llegue al equipo correcto.
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <section class="d-flex flex-column gap-4">
-        <header class="d-flex flex-column flex-lg-row align-items-lg-center gap-3">
-          <div>
-            <h2 class="h4 mb-1">Rutas públicas disponibles</h2>
-            <p class="text-muted mb-0">Consulta y consume los endpoints sin autenticación previa.</p>
-          </div>
-          <a class="btn btn-link ms-lg-auto" routerLink="/reserve">Ir a reservas</a>
-        </header>
-
-        <div class="row g-4">
-          <div class="col-12 col-md-6 col-xxl-4" *ngFor="let endpoint of endpoints">
-            <article class="card h-100 shadow-sm border-0">
-              <div class="card-body d-flex flex-column gap-3">
-                <div class="d-flex align-items-center gap-3">
-                  <span
-                    class="badge text-uppercase"
-                    [ngClass]="endpoint.method === 'GET' ? 'text-bg-success' : 'text-bg-warning'"
-                  >
-                    {{ endpoint.method }}
-                  </span>
-                  <code class="text-primary-emphasis fw-semibold">{{ endpoint.path }}</code>
-                </div>
-                <div>
-                  <h3 class="h5 mb-1">{{ endpoint.title }}</h3>
-                  <p class="text-muted mb-0">{{ endpoint.description }}</p>
-                </div>
-              </div>
-            </article>
-          </div>
-        </div>
-      </section>
-
-      <section class="bg-dark text-white rounded-4 shadow-sm p-4 p-lg-5 d-flex flex-column gap-4">
-        <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center">
-          <div class="flex-grow-1">
-            <h2 class="h4 mb-2">Ejemplo de reserva correcta</h2>
-            <p class="text-white-50 mb-0">
-              Antes de confirmar, valida que tu cuerpo JSON respete la estructura solicitada. Puedes
-              copiar este formato como referencia.
-            </p>
-          </div>
-          <a class="btn btn-outline-light px-4" routerLink="/reserve">Generar mi reserva</a>
-        </div>
-        <pre class="bg-black text-white rounded-4 p-4 mb-0 overflow-auto">
-          <code [innerText]="reservationExample"></code>
-        </pre>
-      </section>
+    <section class="d-flex flex-column align-items-center text-center gap-4 py-5">
+      <span class="badge text-bg-primary text-uppercase">Librería Lumen</span>
+      <h1 class="display-4 fw-semibold mb-0">¡Explora nuestro catálogo!</h1>
+      <p class="text-muted fs-5 mb-0">
+        Descubre los títulos disponibles y encuentra tu próxima lectura favorita.
+      </p>
+      <a class="btn btn-primary btn-lg px-4" routerLink="/catalog">Ver catálogo</a>
     </section>
   `
 })
-export class PublicHomeComponent {
-  readonly endpoints: PublicEndpoint[] = [
-    {
-      method: 'GET',
-      path: '/public/products',
-      title: 'Catálogo público',
-      description: 'Obtén el listado completo de productos disponibles con información de stock.'
-    },
-    {
-      method: 'GET',
-      path: '/public/products/{id}',
-      title: 'Detalle de producto',
-      description: 'Consulta la información detallada de un producto específico usando su identificador.'
-    },
-    {
-      method: 'GET',
-      path: '/public/categories',
-      title: 'Listado de categorías',
-      description: 'Explora las categorías para organizar y filtrar los productos del catálogo.'
-    },
-    {
-      method: 'GET',
-      path: '/public/categories/{id}',
-      title: 'Detalle de categoría',
-      description: 'Recupera la descripción y los productos asociados a una categoría concreta.'
-    },
-    {
-      method: 'POST',
-      path: '/public/reservations',
-      title: 'Crear reserva',
-      description: 'Envía los datos completos del cliente y los productos para apartar unidades disponibles.'
-    }
-  ];
-
-  readonly reservationExample = `{
-  "customerData": {
-    "firstName": "string",
-    "lastName": "string",
-    "dni": "37999589",
-    "email": "user@example.com",
-    "phone": "(71())05+9(544 89"
-  },
-  "items": [
-    {
-      "productId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-      "quantity": 1
-    }
-  ],
-  "pickupDeadline": "2025-09-26T02:26:14.200Z",
-  "notes": "string"
-}`;
-}
+export class PublicHomeComponent {}

--- a/src/app/features/public/views/product-detail.component.ts
+++ b/src/app/features/public/views/product-detail.component.ts
@@ -26,7 +26,7 @@ import { PublicProductView } from '../../../core/models';
         <div class="card-body d-flex flex-column gap-4">
           <header class="d-flex flex-column flex-lg-row gap-3 align-items-lg-start">
             <div class="flex-grow-1">
-              <h1 class="h3 mb-2">{{ product.name }}</h1>
+              <h1 class="h3 mb-2">{{ product.title || product.name || 'Sin título' }}</h1>
               <p class="text-primary fw-semibold mb-2" *ngIf="product.author">{{ product.author }}</p>
               <span class="badge text-bg-secondary" *ngIf="product.categoryName">
                 {{ product.categoryName }}
@@ -34,10 +34,7 @@ import { PublicProductView } from '../../../core/models';
             </div>
             <div class="text-lg-end">
               <p class="display-6 fw-bold mb-1">
-                {{ product.price | currency: product.currency }}
-              </p>
-              <p class="text-muted mb-0" *ngIf="product.availableStock !== undefined">
-                {{ product.availableStock }} unidades disponibles
+                {{ product.price | currency: (product.currency || 'MXN') }}
               </p>
             </div>
           </header>
@@ -50,28 +47,10 @@ import { PublicProductView } from '../../../core/models';
 
             <dt class="col-sm-3">Categoría</dt>
             <dd class="col-sm-9">{{ product.categoryName || 'Sin categoría' }}</dd>
-
-            <dt class="col-sm-3">Disponibilidad</dt>
-            <dd class="col-sm-9">
-              <span
-                [ngClass]="{
-                  'text-success fw-semibold': product.availableStock !== undefined && product.availableStock > 0,
-                  'text-danger fw-semibold': product.availableStock !== undefined && product.availableStock === 0
-                }"
-              >
-                {{ product.availableStock !== undefined ? product.availableStock + ' unidades' : 'Consultar en tienda' }}
-              </span>
-            </dd>
           </dl>
 
           <div class="d-flex flex-wrap gap-2">
             <a class="btn btn-primary" routerLink="/reserve">Reservar este título</a>
-            <a
-              class="btn btn-outline-secondary"
-              routerLink="/categories"
-            >
-              Explorar categorías
-            </a>
           </div>
         </div>
       </article>

--- a/src/app/features/public/views/reserve.component.ts
+++ b/src/app/features/public/views/reserve.component.ts
@@ -1,13 +1,9 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, inject, signal } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { AbstractControl, FormBuilder, ReactiveFormsModule, ValidatorFn, Validators } from '@angular/forms';
 import { finalize } from 'rxjs';
 import { PublicProductsApi, PublicReservationsApi } from '../../../core/api';
-import {
-  PublicProductView,
-  PublicReservationCreateRequest,
-  PublicReservationCreatedResponse
-} from '../../../core/models';
+import { PublicProductView, PublicReservationCreateRequest } from '../../../core/models';
 
 @Component({
   selector: 'app-reserve',
@@ -17,16 +13,17 @@ import {
     <section class="d-flex flex-column gap-4">
       <header class="bg-white shadow-sm rounded-4 p-4 border">
         <h1 class="h3 mb-2">Reserva con LIBRERIA LUMEN</h1>
-        <p class="text-muted mb-0">
-          Completa tus datos y selecciona un producto para apartarlo. Antes de enviar, revisa el cuerpo
-          JSON para asegurarte de que coincide exactamente con el formato requerido por la API pública.
-        </p>
+        <p class="text-muted mb-0">Completa tus datos y selecciona un producto para enviar la solicitud.</p>
       </header>
 
       <div class="row g-4">
         <div class="col-12 col-xl-8">
           <form class="card shadow-sm border-0" [formGroup]="form" (ngSubmit)="submit()" novalidate>
             <div class="card-body p-4">
+              <div class="alert alert-success" role="status" *ngIf="successMessage()">
+                {{ successMessage() }}
+              </div>
+
               <fieldset class="border-0 p-0" [disabled]="loading()">
                 <div class="row g-4">
                   <div class="col-12">
@@ -140,10 +137,7 @@ import {
                     >
                       <option value="" disabled>Selecciona un producto</option>
                       <option *ngFor="let product of products(); trackBy: trackByProduct" [value]="product.id">
-                        {{ product.name }}
-                        <ng-container *ngIf="product.availableStock !== undefined">
-                          ({{ product.availableStock }} disponibles)
-                        </ng-container>
+                        {{ product.title || product.name || 'Sin título' }}
                       </option>
                     </select>
                     <div class="invalid-feedback" *ngIf="hasError('productId', 'required')">
@@ -226,40 +220,13 @@ import {
         </div>
 
         <div class="col-12 col-xl-4">
-          <div class="d-flex flex-column gap-3">
-            <div class="card shadow-sm border-0 h-100">
-              <div class="card-body d-flex flex-column gap-3">
-                <h2 class="h5 mb-0">Confirmación de reserva</h2>
-                <p class="text-muted mb-0">
-                  Recibirás un correo con el código y la fecha límite una vez confirmada la reserva.
-                </p>
-
-                <div *ngIf="confirmation() as result; else pending">
-                  <div class="alert alert-success mb-0" role="status">
-                    <h3 class="h6 fw-semibold">Reserva generada</h3>
-                    <p class="mb-1"><strong>Código:</strong> {{ result.code }}</p>
-                    <p class="mb-1"><strong>ID interno:</strong> {{ result.reservationId }}</p>
-                    <p class="mb-0" *ngIf="result.expiresAt">
-                      <strong>Vence:</strong> {{ result.expiresAt | date: 'longDate' }}
-                    </p>
-                  </div>
-                </div>
-
-                <ng-template #pending>
-                  <p class="text-muted mb-0">Completa el formulario para generar el código de retiro.</p>
-                </ng-template>
-              </div>
-            </div>
-
-            <div class="card shadow-sm border-0">
-              <div class="card-body d-flex flex-column gap-3">
-                <h2 class="h6 text-uppercase text-muted mb-0">JSON a enviar</h2>
-                <p class="text-muted mb-0">
-                  Verifica cada campo antes de enviar. Este es el cuerpo exacto que se enviará a
-                  <code>POST /public/reservations</code>.
-                </p>
-                <pre class="bg-dark text-white rounded-3 p-3 mb-0 small"><code>{{ requestPreview() }}</code></pre>
-              </div>
+          <div class="card shadow-sm border-0 h-100">
+            <div class="card-body d-flex flex-column gap-3">
+              <h2 class="h5 mb-0">¿Qué sigue?</h2>
+              <p class="text-muted mb-0">
+                Nuestro equipo revisará la información y te contactará para confirmar la disponibilidad y coordinar la entrega.
+              </p>
+              <p class="text-muted mb-0">Si tienes dudas adicionales, puedes dejarlas en el campo de observaciones.</p>
             </div>
           </div>
         </div>
@@ -294,30 +261,7 @@ export class ReserveComponent {
   readonly loading = signal(false);
   readonly error = signal('');
   readonly products = signal<PublicProductView[]>([]);
-  readonly confirmation = signal<PublicReservationCreatedResponse | null>(null);
-
-  readonly requestPreview = computed(() => {
-    const raw = this.form.getRawValue();
-    const payload = {
-      customerData: {
-        firstName: raw.firstName || '',
-        lastName: raw.lastName || '',
-        dni: raw.dni || '',
-        email: raw.email || '',
-        phone: raw.phone || ''
-      },
-      items: [
-        {
-          productId: raw.productId || '',
-          quantity: raw.quantity ?? 1
-        }
-      ],
-      pickupDeadline: raw.pickupDeadline ? this.toIsoString(raw.pickupDeadline) : '',
-      ...(raw.notes ? { notes: raw.notes } : {})
-    } satisfies PublicReservationCreateRequest & { notes?: string };
-
-    return JSON.stringify(payload, null, 2);
-  });
+  readonly successMessage = signal('');
 
   readonly pickupDeadlineMinValue = this.toInputLocalValue(new Date());
 
@@ -358,14 +302,14 @@ export class ReserveComponent {
 
     this.loading.set(true);
     this.error.set('');
-    this.confirmation.set(null);
+    this.successMessage.set('');
 
     this.publicReservationsApi
       .create(request)
       .pipe(finalize(() => this.loading.set(false)))
       .subscribe({
-        next: (response) => {
-          this.confirmation.set(response);
+        next: () => {
+          this.successMessage.set('Reserva enviada correctamente. Te contactaremos con la confirmación.');
           this.form.reset({
             firstName: '',
             lastName: '',
@@ -379,6 +323,7 @@ export class ReserveComponent {
           });
         },
         error: () => {
+          this.successMessage.set('');
           this.error.set('No se pudo crear la reserva. Intenta nuevamente.');
         }
       });
@@ -393,11 +338,11 @@ export class ReserveComponent {
     this.error.set('');
 
     this.publicProductsApi
-      .list({ page: 1, pageSize: 50 })
+      .list()
       .pipe(finalize(() => this.loading.set(false)))
       .subscribe({
         next: (response) => {
-          this.products.set(response.items);
+          this.products.set(response);
         },
         error: () => {
           this.error.set('No se pudieron cargar los productos.');


### PR DESCRIPTION
## Summary
- ensure the public reservation model wraps customer details under `customerData` to match the POST /public/reservations contract
- adjust the reserve page messaging to guide customers without exposing endpoint-specific details
- retain the streamlined success flow introduced previously for reservation submissions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5fc2e536483298d50bbf1fe82d9cd